### PR TITLE
Fix: charity bot image issue

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/TestUtils.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/TestUtils.swift
@@ -8,6 +8,7 @@ public class TestUtils {
         "https://picsum.photos/id/1062/620/287": NSSize(width: 620, height: 287),
         "https://picsum.photos/id/1062/620/1080": NSSize(width: 620, height: 1080),
         "https://picsum.photos/id/1080/630/1080": NSSize(width: 630, height: 1080),
+        "https://picsum.photos/id/153/960/506": NSSize(width: 960, height: 506),
         "https://media.istockphoto.com/vectors/origamisign2blue-vector-id1159533161?k=6&m=1159533161&s=612x612&w=0&h=YpKhQtcoi-Z4JYrnqihgwcxdsTzjRP8UWJchAUyyMgI=": NSSize(width: 612, height: 284),
         "https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg": NSSize(width: 400, height: 400),
         "https://messagecardplayground.azurewebsites.net/assets/LocationGreen_A.png": NSSize(width: 23, height: 35),

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ImageCharity.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ImageCharity.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "columns": [
+                {
+                    "items": [
+                        {
+                            "altText": "",
+                            "size": "Medium",
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/153/960/506"
+                        }
+                    ],
+                    "type": "Column",
+                    "width": "auto"
+                }
+            ],
+            "type": "ColumnSet"
+        },
+        {
+            "horizontalAlignment": "Center",
+            "size": "Medium",
+            "spacing": "Medium",
+            "text": "Cisco Manager Charity Match Drive 2021",
+            "type": "TextBlock",
+            "weight": "Bolder"
+        },
+        {
+            "text": "Hello!! Welcome to Cisco's 2021 Charity Match Drive. My name is Charity Bot.",
+            "type": "TextBlock",
+            "wrap": true
+        },
+        {
+            "horizontalAlignment": "Left",
+            "spacing": "Medium",
+            "text": "Please select your role.",
+            "type": "TextBlock"
+        },
+        {
+            "columns": [
+                {
+                    "horizontalAlignment": "Center",
+                    "items": [
+                        {
+                            "actions": [
+                                {
+                                    "data": {
+                                        "buttonId": "employeeBtn"
+                                    },
+                                    "id": "employeeBtn",
+                                    "title": "Employee",
+                                    "type": "Action.Submit"
+                                }
+                            ],
+                            "type": "ActionSet"
+                        }
+                    ],
+                    "type": "Column",
+                    "width": "stretch"
+                },
+                {
+                    "horizontalAlignment": "Center",
+                    "items": [
+                        {
+                            "actions": [
+                                {
+                                    "data": {
+                                        "buttonId": "managerBtn"
+                                    },
+                                    "id": "managerBtn",
+                                    "title": "Manager",
+                                    "type": "Action.Submit"
+                                }
+                            ],
+                            "type": "ActionSet"
+                        }
+                    ],
+                    "type": "Column",
+                    "width": "stretch"
+                }
+            ],
+            "type": "ColumnSet"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.2"
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -101,9 +101,14 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             logError("imageProperties is null")
             return
         }
-        let constraintIds = ["imageHeight", "imageWidth", "imageAspect", "imageAuto"]
         imageProperties.updateContentSize(size: imageSize)
         
+        enum ImageViewConstraint: String {
+            case imageHeight = "imageHeightValue"
+            case imageWidth = "imageWidthValue"
+            case imageAspect = "imageAspectValue"
+            case imageAuto = "imageAutoValue"
+        }
         let cgSize = imageProperties.contentSize
         let priority = self.getImageUILayoutPriority(imageView.superview)
         var constraints: [NSLayoutConstraint] = []
@@ -112,9 +117,9 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         constraints.append(NSLayoutConstraint(item: imageView, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: cgSize.width))
         constraints.append(NSLayoutConstraint(item: imageView, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: cgSize.height))
         constraints[0].priority = priority
-        constraints[0].identifier = "imageWidth"
+        constraints[0].identifier = ImageViewConstraint.imageWidth.rawValue
         constraints[1].priority = priority
-        constraints[1].identifier = "imageHeight"
+        constraints[1].identifier = ImageViewConstraint.imageHeight.rawValue
         
         // This constraint fit image in container with a aspect ratio
         let aspectRatio = ACRImageProperties.convertToAspectRatio(cgSize)
@@ -125,16 +130,16 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         // Give the aspect ratio constraint a two-digit priority boost for first fulfilment. Priorities are calculated when the window loads the view. Otherwise, a constraint conflict will occur.
         constraints[2].priority = priority + 2
-        constraints[2].identifier = "imageAspect"
+        constraints[2].identifier = ImageViewConstraint.imageAspect.rawValue
         
         if imageProperties.acsImageSize == .auto {
             constraints.append(imageView.widthAnchor.constraint(lessThanOrEqualToConstant: imageProperties.contentSize.width))
-            constraints[3].identifier = "imageAuto"
+            constraints[3].identifier = ImageViewConstraint.imageAuto.rawValue
         }
         
         // remove old constraint to avoid dublicates
         for constraint in imageView.constraints {
-            if constraintIds.contains(constraint.identifier ?? "") {
+            if ImageViewConstraint(rawValue: constraint.identifier ?? "") != nil {
                 NSLayoutConstraint.deactivate([constraint])
             }
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -101,30 +101,43 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             logError("imageProperties is null")
             return
         }
-        
+        let constraintIds = ["imageHeight", "imageWidth", "imageAspect", "imageAuto"]
         imageProperties.updateContentSize(size: imageSize)
         
         let cgSize = imageProperties.contentSize
         let priority = self.getImageUILayoutPriority(imageView.superview)
         var constraints: [NSLayoutConstraint] = []
         
+        // This constraint need for image size [small, medium, large]
         constraints.append(NSLayoutConstraint(item: imageView, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: cgSize.width))
         constraints.append(NSLayoutConstraint(item: imageView, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: cgSize.height))
         constraints[0].priority = priority
+        constraints[0].identifier = "imageWidth"
         constraints[1].priority = priority
+        constraints[1].identifier = "imageHeight"
         
+        // This constraint fit image in container with a aspect ratio
         let aspectRatio = ACRImageProperties.convertToAspectRatio(cgSize)
-        
-        constraints.append(NSLayoutConstraint(item: imageView, attribute: .height, relatedBy: .equal, toItem: imageView, attribute: .width, multiplier: aspectRatio.heightToWidth, constant: 0))
-        constraints.append(NSLayoutConstraint(item: imageView, attribute: .width, relatedBy: .equal, toItem: imageView, attribute: .height, multiplier: aspectRatio.widthToHeight, constant: 0))
+        if aspectRatio.heightToWidth != 0 {
+            constraints.append(NSLayoutConstraint(item: imageView, attribute: .height, relatedBy: .equal, toItem: imageView, attribute: .width, multiplier: aspectRatio.heightToWidth, constant: 0))
+        } else if aspectRatio.widthToHeight != 0 {
+            constraints.append(NSLayoutConstraint(item: imageView, attribute: .width, relatedBy: .equal, toItem: imageView, attribute: .height, multiplier: aspectRatio.widthToHeight, constant: 0))
+        }
         // Give the aspect ratio constraint a two-digit priority boost for first fulfilment. Priorities are calculated when the window loads the view. Otherwise, a constraint conflict will occur.
         constraints[2].priority = priority + 2
-        constraints[3].priority = priority + 2
+        constraints[2].identifier = "imageAspect"
         
         if imageProperties.acsImageSize == .auto {
             constraints.append(imageView.widthAnchor.constraint(lessThanOrEqualToConstant: imageProperties.contentSize.width))
+            constraints[3].identifier = "imageAuto"
         }
         
+        // remove old constraint to avoid dublicates
+        for constraint in imageView.constraints {
+            if constraintIds.contains(constraint.identifier ?? "") {
+                NSLayoutConstraint.deactivate([constraint])
+            }
+        }
         NSLayoutConstraint.activate(constraints)
         superView.update(imageProperties: imageProperties)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -10,7 +10,7 @@ class ACRViewTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        view = ACRView(style: .default, hostConfig: FakeHostConfig.make(), renderConfig: .default)
+        view = ACRView(style: .default, hostConfig: FakeHostConfig.make(), renderConfig: .default, visibilityContext: ACOVisibilityContext())
         fakeResourceResolver = FakeResourceResolver()
         actionDelegate = FakeAdaptiveCardActionDelegate()
         
@@ -357,8 +357,8 @@ class ACRViewTests: XCTestCase {
         view.addArrangedSubview(tView2)
         
         // views need to register with visibility manager
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
         
         view.handleToggleVisibilityAction(actionView: NSButton(), toggleTargets: [target1, target2])
         
@@ -378,8 +378,8 @@ class ACRViewTests: XCTestCase {
         view.addArrangedSubview(tView2)
         
         // views need to register with visibility manager
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
         
         view.handleToggleVisibilityAction(actionView: NSButton(), toggleTargets: [target1, target2])
         
@@ -400,8 +400,8 @@ class ACRViewTests: XCTestCase {
         
         
         // views need to register with visibility manager
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
         
         view.handleToggleVisibilityAction(actionView: NSButton(), toggleTargets: [target1, target2])
         
@@ -426,9 +426,9 @@ class ACRViewTests: XCTestCase {
         
         
         // views need to register with visibility manager
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
-        view.visibilityContext.registerVisibilityManager(view, targetViewIdentifier: tView3.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView1.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView2.identifier)
+        view.visibilityContext?.registerVisibilityManager(view, targetViewIdentifier: tView3.identifier)
         
         view.handleToggleVisibilityAction(actionView: NSButton(), toggleTargets: [target1, target2, target3])
         


### PR DESCRIPTION
- update imagerenderer
- update test case for visibility context
- add json file

**Before**    |  **Updated**
:-------------------------:|:-------------------------:
<img width="442" alt="Screenshot 2022-10-03 at 10 48 20 AM" src="https://user-images.githubusercontent.com/105660080/193544042-17891d68-562c-41d1-bfee-d741ab873103.png">|<img width="444" alt="Screenshot 2022-10-03 at 10 48 37 AM" src="https://user-images.githubusercontent.com/105660080/193544071-12463134-b4fc-481c-945c-192b97e149f8.png">


## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
