### PR TITLE
Fixed: ACSFillerManager.getSeparator crash

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/SeparatorNoneTest.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/SeparatorNoneTest.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "size": "Medium",
+            "text": "Hi, I'm Rememory!",
+            "type": "TextBlock",
+            "weight": "Bolder",
+            "wrap": true
+        },
+        {
+            "size": "Medium",
+            "text": "I can help you and your team remember tasks, important events, due dates and more.",
+            "type": "TextBlock",
+            "wrap": true,
+            "isVisible": false,
+            "spacing": "None"
+        },
+        {
+            "id": "card_id",
+            "isVisible": true,
+            "placeholder": "Placeholder text",
+            "type": "Input.Text",
+            "value": "helpcard",
+            "spacing": "None"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.2"
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
@@ -40,7 +40,7 @@ class StretchableView: NSView {
 
 class ACSFillerSpaceManager {
     private var paddingMap: NSMapTable<NSView, NSMutableArray>
-    private var separatorMap: NSMapTable<NSView, NSValue>
+    private var separatorMap: NSMapTable<NSView, NSView>
     private var stretchableViewSet: NSHashTable<NSView>
     private var stretchableViews: [NSValue]
     private var paddingSet: NSHashTable<NSView>
@@ -48,7 +48,7 @@ class ACSFillerSpaceManager {
     
     init() {
         paddingMap = NSMapTable<NSView, NSMutableArray>(keyOptions: .weakMemory, valueOptions: .strongMemory)
-        separatorMap = NSMapTable<NSView, NSValue>(keyOptions: .weakMemory, valueOptions: .strongMemory)
+        separatorMap = NSMapTable<NSView, NSView>(keyOptions: .weakMemory, valueOptions: .weakMemory)
         stretchableViewSet = NSHashTable<NSView>(options: .weakMemory, capacity: 5)
         stretchableViews = [NSValue]()
         paddingSet = NSHashTable<NSView>(options: .weakMemory, capacity: 5)
@@ -147,14 +147,15 @@ class ACSFillerSpaceManager {
         return paddingMap.object(forKey: view) as? [NSValue]
     }
     
-    func associateSeparator(withOwnerView separator: NSView?, ownerView: NSView?) {
-        separatorMap.setObject(NSValue(nonretainedObject: separator), forKey: ownerView)
+    func associateSeparator(withOwnerView separator: NSView, ownerView: NSView) {
+        separatorMap.setObject(separator, forKey: ownerView)
     }
     
     func getSeparatorFor(ownerView: NSView) -> SpacingView? {
-        if let value = separatorMap.object(forKey: ownerView) {
-            return value.nonretainedObjectValue as? SpacingView
+        guard let objSpaceView = separatorMap.object(forKey: ownerView), let spaceView = objSpaceView as? SpacingView else {
+            logError("For OwnerView, Separator not found in separatorMapTable.")
+            return nil
         }
-        return nil
+        return spaceView
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
@@ -11,8 +11,8 @@ import AppKit
 
 /// VisibilityManager protocols for handle element visibility
 @objc protocol ACSVisibilityManagerFacade {
-    func hideView(_ view: NSView)
-    func unhideView(_ view: NSView)
+    func visibilityManager(hideView view: NSView)
+    func visibilityManager(unhideView view: NSView)
 }
 
 class ACSVisibilityManager {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -47,7 +47,9 @@ class BaseCardElementRenderer {
             }
         }
         // visibility changes add on height support element, so need to manually register with visibility manager for other elements. this will remove after once elements are support by height changs.
-        rootView.associateSeparator(withOwnerView: separator, ownerView: updatedView)
+        if let separator = separator {
+            rootView.associateSeparator(withOwnerView: separator, ownerView: updatedView)
+        }
         // Through the root view visibility context, register renderview with self manager.
         rootView.visibilityContext?.registerVisibilityManager(rootView, targetViewIdentifier: updatedView.identifier)
         if !element.getIsVisible() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -15,13 +15,6 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
         columnView.bleed = column.getBleed()
         
-        var topSpacingView: SpacingView?
-        if column.getVerticalContentAlignment() == .center || column.getVerticalContentAlignment() == .bottom {
-            let view = SpacingView()
-            columnView.addArrangedSubview(view)
-            topSpacingView = view
-        }
-        
         for (index, element) in column.getItems().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
@@ -32,12 +25,6 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         }
         
         columnView.configureLayoutAndVisibility(column.getVerticalContentAlignment(), minHeight: column.getMinHeight(), heightType: column.getHeight(), type: .column)
-        
-        if column.getVerticalContentAlignment() == .center, let topView = topSpacingView {
-            let view = SpacingView()
-            columnView.addArrangedSubview(view)
-            view.heightAnchor.constraint(equalTo: topView.heightAnchor).isActive = true
-        }
         
         if let backgroundImage = column.getBackgroundImage(), let url = backgroundImage.getUrl() {
             columnView.setupBackgroundImageProperties(backgroundImage)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -19,13 +19,6 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
         containerView.setupSelectAction(container.getSelectAction(), rootView: rootView)
         containerView.setupSelectActionAccessibility(on: containerView, for: container.getSelectAction())
         
-        var leadingBlankSpace: SpacingView?
-        if container.getVerticalContentAlignment() == .center || container.getVerticalContentAlignment() == .bottom {
-            let view = SpacingView()
-            containerView.addArrangedSubview(view)
-            leadingBlankSpace = view
-        }
-        
         for (index, element) in container.getItems().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
@@ -34,13 +27,6 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: element, parentElement: container)
         }
         containerView.configureLayoutAndVisibility(container.getVerticalContentAlignment(), minHeight: container.getMinHeight(), heightType: container.getHeight(), type: .container)
-        
-        // Dont add the trailing space if the vertical content alignment is top/default
-        if container.getVerticalContentAlignment() == .center, let topView = leadingBlankSpace {
-            let view = SpacingView()
-            containerView.addArrangedSubview(view)
-            view.heightAnchor.constraint(equalTo: topView.heightAnchor).isActive = true
-        }
         containerView.wantsLayer = true
         return containerView
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -58,9 +58,10 @@ class ACRColumnSetView: ACRContentStackView {
     /// call this method after subview is rendered
     /// it configures height, creates association between the subview and its separator if any
     /// registers subview for its visibility
-    override func updateLayoutAndVisibilityOfRenderedView(_ renderedView: NSView?, acoElement acoElem: ACSBaseCardElement?, separator: SpacingView?, rootView: ACRView?) {
-        guard let renderedView = renderedView, let acoElem = acoElem else { return }
-        self.associateSeparator(withOwnerView: separator, ownerView: renderedView)
+    override func updateLayoutAndVisibilityOfRenderedView(_ renderedView: NSView, acoElement acoElem: ACSBaseCardElement, separator: SpacingView?, rootView: ACRView?) {
+        if let separator = separator {
+            self.associateSeparator(withOwnerView: separator, ownerView: renderedView)
+        }
         rootView?.visibilityContext?.registerVisibilityManager(self, targetViewIdentifier: renderedView.identifier)
         if !acoElem.getIsVisible() {
             self.register(invisibleView: renderedView)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -164,9 +164,9 @@ class ACRView: ACRColumnView {
             }
             if let facade = facade {
                 if isHide {
-                    facade.hideView(toggleView)
+                    facade.visibilityManager(hideView: toggleView)
                 } else {
-                    facade.unhideView(toggleView)
+                    facade.visibilityManager(unhideView: toggleView)
                 }
             }
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/SpacingView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/SpacingView.swift
@@ -28,9 +28,11 @@ class SpacingView: NSView {
     ///   - config: Host Config
     /// - Returns: Spacer
     class func renderSpacer(elem: ACSBaseCardElement, forSuperView view: ACRContentStackView, withHostConfig config: ACSHostConfig) -> SpacingView? {
-        let separator = SpacingView()
         let requestedSpacing = elem.getSpacing()
-        if requestedSpacing != .none {
+        if requestedSpacing == .none {
+            return nil
+        } else {
+            let separator = SpacingView()
             separator.orientation = view.orientation
             let spacing = HostConfigUtils.getSpacing(requestedSpacing, with: config).doubleValue
             separator.spacing = spacing
@@ -44,8 +46,8 @@ class SpacingView: NSView {
             separator.layer?.backgroundColor = .clear
             view.addArrangedSubview(separator)
             separator.configConstraintLayout()
+            return separator
         }
-        return separator
     }
     
     func configConstraintLayout() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
@@ -20,7 +20,7 @@ class AdaptiveCardsTests: XCTestCase {
     
     func testRetainCycles() {
         let bundle = Bundle(for: type(of: self))
-        let fileNames = ["ActivityUpdate", "ActionSetSample", "ImageGallery", "Agenda"]
+        let fileNames = ["ActivityUpdate", "ActionSetSample", "ImageGallery", "Agenda", "SeparatorNoneTest"]
         let jsons = fileNames.map { NSDataAsset(name: $0 + ".json", bundle: bundle)!.data }
                         .map { String(data: $0, encoding: .utf8)! }
         
@@ -34,6 +34,7 @@ class AdaptiveCardsTests: XCTestCase {
         weak var weakCard2: NSView?
         weak var weakCard3: NSView?
         weak var weakCard4: NSView?
+        weak var weakCard5: NSView?
         
         var blockExecuted = false
         autoreleasepool {
@@ -41,6 +42,7 @@ class AdaptiveCardsTests: XCTestCase {
             let card2 = AdaptiveCard.render(card: cards[1], with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
             let card3 = AdaptiveCard.render(card: cards[2], with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
             let card4 = AdaptiveCard.render(card: cards[3], with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
+            let card5 = AdaptiveCard.render(card: cards[4], with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
             
             // Simulate show card action
             guard let showCardButton = card1.buttonInHierachy(withTitle: "Set due date") else {
@@ -53,11 +55,13 @@ class AdaptiveCardsTests: XCTestCase {
             weakCard2 = card2
             weakCard3 = card3
             weakCard4 = card4
+            weakCard5 = card5
             
             XCTAssertNotNil(weakCard1)
             XCTAssertNotNil(weakCard2)
             XCTAssertNotNil(weakCard3)
             XCTAssertNotNil(weakCard4)
+            XCTAssertNotNil(weakCard5)
             
             blockExecuted = true
         }
@@ -67,6 +71,7 @@ class AdaptiveCardsTests: XCTestCase {
         XCTAssertNil(weakCard2)
         XCTAssertNil(weakCard3)
         XCTAssertNil(weakCard4)
+        XCTAssertNil(weakCard5)
     }
     
     func testChildToParentToggleVisibility() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextBlock.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextBlock.swift
@@ -132,7 +132,7 @@ class FakeTextBlock: ACSTextBlock {
 }
 
 extension FakeTextBlock {
-    static func make(text: String? = "", textForDateParsing: ACSDateTimePreparser? = nil, textSize: ACSTextSize = .default, heightType: ACSHeightType = .auto, textWeight: ACSTextWeight = .default, fontType: ACSFontType = .default, textColor: ACSForegroundColor = .default, wrap: Bool = false, isSubtle: Bool = false, maxLines: NSNumber = 0, horizontalAlignment: ACSHorizontalAlignment = .left, language: String? = "", separator: Bool = false, isVisible: Bool = false, spacing: ACSSpacing = .default) -> FakeTextBlock {
+    static func make(text: String? = "", textForDateParsing: ACSDateTimePreparser? = nil, textSize: ACSTextSize = .default, heightType: ACSHeightType = .auto, textWeight: ACSTextWeight = .default, fontType: ACSFontType = .default, textColor: ACSForegroundColor = .default, wrap: Bool = false, isSubtle: Bool = false, maxLines: NSNumber = 0, horizontalAlignment: ACSHorizontalAlignment = .left, language: String? = "", separator: Bool = false, isVisible: Bool = true, spacing: ACSSpacing = .default) -> FakeTextBlock {
         let fakeTextBlock = FakeTextBlock()
         fakeTextBlock.text = text
         fakeTextBlock.textForDateParsing = textForDateParsing

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -68,6 +68,18 @@ class BaseCardElementRendererrTests: XCTestCase {
         XCTAssertEqual(viewWithInheritedProperties.identifier?.rawValue, "helloworld")
     }
     
+    func testSeparatorSpacingCrash() {
+        // Test case when spacing is none and element is hidden
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeRootView = ACRView.init(style: .none, hostConfig: hostConfig, renderConfig: config)
+        
+        let invisibleInputNumber = FakeInputNumber.make(id: "1", visible: false, spacing: .none)
+        let container = FakeContainer.make(items: [invisibleInputNumber])
+        let containerView = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: fakeRootView, parentView: fakeRootView, inputs: [], config: config)
+        guard let containerView = containerView as? ACRContainerView else { fatalError() }
+        guard let inputNumberView = containerView.stackView.findView(withIdentifier: "1") as? ACRNumericTextField else { fatalError() }
+    }
+    
     func testInputTextErrorMessageHandler() {
         let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
         let fakeRootView = ACRView.init(style: .none, hostConfig: hostConfig, renderConfig: config)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -53,11 +53,11 @@ class ColumnRendererTests: XCTestCase {
         var columnView = renderColumnView()
         XCTAssertEqual(columnView.arrangedSubviews.count, 1)
         
-        column = .make(verticalContentAlignment: .center)
+        column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .center)
         columnView = renderColumnView()
         XCTAssertEqual(columnView.arrangedSubviews.count, 3)
         
-        column = .make(verticalContentAlignment: .bottom)
+        column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .bottom)
         columnView = renderColumnView()
         XCTAssertEqual(columnView.arrangedSubviews.count, 2)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -38,12 +38,12 @@ class ContainerRendererTests: XCTestCase {
         // For HeightType Property we have add stretchable view. so it will increase count for subviews.
         XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 1)
         
-        container = .make(verticalContentAlignment: .bottom)
+        container = .make(verticalContentAlignment: .bottom, items: [FakeTextBlock.make()])
         containerView = renderContainerView(container)
         // SpaceView 1
         XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 2)
         
-        container = .make(verticalContentAlignment: .center)
+        container = .make(verticalContentAlignment: .center, items: [FakeTextBlock.make()])
         containerView = renderContainerView(container)
         // SpaceView 2
         XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 3)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/SeparatorNoneTest.json.dataset/Contents.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/SeparatorNoneTest.json.dataset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "data" : [
+    {
+      "filename" : "SeparatorNoneTest.json",
+      "idiom" : "universal",
+      "universal-type-identifier" : "public.json"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/SeparatorNoneTest.json.dataset/SeparatorNoneTest.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/SeparatorNoneTest.json.dataset/SeparatorNoneTest.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "size": "Medium",
+            "text": "Hi, I'm Rememory!",
+            "type": "TextBlock",
+            "weight": "Bolder",
+            "wrap": true
+        },
+        {
+            "size": "Medium",
+            "text": "I can help you and your team remember tasks, important events, due dates and more.",
+            "type": "TextBlock",
+            "wrap": true,
+            "isVisible": false,
+            "spacing": "None"
+        },
+        {
+            "id": "card_id",
+            "isVisible": true,
+            "placeholder": "Placeholder text",
+            "type": "Input.Text",
+            "value": "helpcard",
+            "spacing": "None"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.2"
+}


### PR DESCRIPTION
- change is SpacingView.renderSpacer return nil when separator == None
- add not nil separator scenario at associateSeparatorWithOwner method
- Remove nonretainObject strong reference to weak reference NSView
- handle nil scenario
- Minor changes

## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
