### PR TITLE
Stretchable View not working properly at first time after Action.Toggle

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityBasicCase.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityBasicCase.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "actions": [
+        {
+            "title": "OK",
+            "type": "Action.Submit"
+        }
+    ],
+    "body": [
+        {
+            "errorMessage": "error message error message error message error message ",
+            "height": "stretch",
+            "id": "1",
+            "isRequired": true,
+            "label": "Hello this is label",
+            "type": "Input.Date",
+            "isVisible": true
+        },
+        {
+            "errorMessage": "error message error message error message error message ",
+            "height": "stretch",
+            "id": "3",
+            "isRequired": true,
+            "label": "This is label",
+            "type": "Input.Time",
+            "isVisible": true
+        },
+        {
+            "actions": [
+                {
+                    "targetElements": [
+                        "1",
+                        "3"
+                    ],
+                    "title": "Action.ToggleVisibility",
+                    "type": "Action.ToggleVisibility"
+                }
+            ],
+            "id": "2",
+            "type": "ActionSet"
+        }
+    ],
+    "minHeight": "400px",
+    "type": "AdaptiveCard",
+    "version": "1.3"
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityInContainer.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityInContainer.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "1",
+                    "isRequired": true,
+                    "label": "Hello this is label",
+                    "type": "Input.Date",
+                    "isVisible": true
+                },
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "3",
+                    "isRequired": true,
+                    "label": "This is label",
+                    "type": "Input.Time",
+                    "isVisible": true
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "1",
+                                "3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "2",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch"
+        }
+    ],
+
+            "minHeight": "400px",
+    "type": "AdaptiveCard",
+    "version": "1.3"
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityShowCard.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LastElementVisibilityShowCard.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "1",
+                    "isRequired": true,
+                    "label": "Hello this is label",
+                    "type": "Input.Date",
+                    "isVisible": true
+                },
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "3",
+                    "isRequired": true,
+                    "label": "This is label",
+                    "type": "Input.Time",
+                    "isVisible": true
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "1",
+                                "3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "2",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch",
+            "minHeight": "400px"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.3",
+    "actions": [
+        {
+            "type": "Action.ShowCard",
+            "title": "Action.ShowCard",
+            "card": {
+                "type": "AdaptiveCard",
+                "version": "1.3",
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "body": [
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "11",
+                        "isRequired": true,
+                        "label": "Hello this is label",
+                        "type": "Input.Date",
+                        "isVisible": true
+                    },
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "33",
+                        "isRequired": true,
+                        "label": "This is label",
+                        "type": "Input.Time",
+                        "isVisible": true
+                    },
+                    {
+                        "actions": [
+                            {
+                                "targetElements": [
+                                    "11",
+                                    "33"
+                                ],
+                                "title": "Action.ToggleVisibility",
+                                "type": "Action.ToggleVisibility"
+                            }
+                        ],
+                        "id": "22",
+                        "type": "ActionSet"
+                    }
+                ],
+                "minHeight": "450px"
+            }
+        }
+    ]
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ToggleVisibilityWithMinHeight.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ToggleVisibilityWithMinHeight.json
@@ -1,0 +1,175 @@
+{
+   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+   "actions": [
+      {
+         "card": {
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "body": [
+               {
+                  "errorMessage": "error message error message error message error message ",
+                  "height": "stretch",
+                  "id": "11",
+                  "isRequired": true,
+                  "isVisible": true,
+                  "label": "Hello this is label",
+                  "type": "Input.Date"
+               },
+               {
+                  "errorMessage": "error message error message error message error message ",
+                  "height": "stretch",
+                  "id": "33",
+                  "isRequired": true,
+                  "isVisible": true,
+                  "label": "This is label",
+                  "type": "Input.Time"
+               },
+               {
+                  "type": "Container",
+                  "items": [
+                     {
+                        "type": "Input.Text",
+                        "height": "stretch",
+                        "placeholder": "Placeholder text",
+                        "id": "test2",
+                        "label": "Input Text"
+                     }
+                  ],
+                  "height": "stretch",
+                  "minHeight": "200px"
+               },
+               {
+                  "actions": [
+                     {
+                        "targetElements": [
+                           "11",
+                           "33"
+                        ],
+                        "title": "Action.ToggleVisibility",
+                        "type": "Action.ToggleVisibility"
+                     }
+                  ],
+                  "id": "22",
+                  "type": "ActionSet"
+               }
+            ],
+            "minHeight": "450px",
+            "type": "AdaptiveCard",
+            "version": "1.3"
+         },
+         "title": "Action.ShowCard",
+         "type": "Action.ShowCard"
+      }
+   ],
+   "body": [
+      {
+         "height": "stretch",
+         "items": [
+            {
+               "errorMessage": "error message error message error message error message ",
+               "height": "stretch",
+               "id": "1",
+               "isRequired": true,
+               "isVisible": true,
+               "label": "Hello this is label",
+               "type": "Input.Date"
+            },
+            {
+               "errorMessage": "error message error message error message error message ",
+               "height": "stretch",
+               "id": "3",
+               "isRequired": true,
+               "isVisible": true,
+               "label": "This is label",
+               "type": "Input.Time"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "1",
+                        "3"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "2",
+               "type": "ActionSet"
+            }
+         ],
+         "minHeight": "400px",
+         "type": "Container"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test1",
+               "label": "Input Text"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test3",
+               "label": "Input Text"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "test3"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "ac2",
+               "type": "ActionSet"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test4",
+               "label": "Input Text"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "test4"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "ac3",
+               "type": "ActionSet"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      }
+   ],
+   "type": "AdaptiveCard",
+   "version": "1.3"
+}
+

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ToggleVisibilityWithoutMinHeight.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ToggleVisibilityWithoutMinHeight.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "actions": [
+        {
+            "card": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "body": [
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "11",
+                        "isRequired": true,
+                        "isVisible": true,
+                        "label": "Hello this is label",
+                        "type": "Input.Date"
+                    },
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "33",
+                        "isRequired": true,
+                        "isVisible": true,
+                        "label": "This is label",
+                        "type": "Input.Time"
+                    },
+                    {
+                        "type": "Container",
+                        "items": [
+                            {
+                                "type": "Input.Text",
+                                "height": "stretch",
+                                "placeholder": "Placeholder text",
+                                "id": "test2",
+                                "label": "Input Text"
+                            }
+                        ],
+                        "height": "stretch"
+                    },
+                    {
+                        "actions": [
+                            {
+                                "targetElements": [
+                                    "11",
+                                    "33"
+                                ],
+                                "title": "Action.ToggleVisibility",
+                                "type": "Action.ToggleVisibility"
+                            }
+                        ],
+                        "id": "22",
+                        "type": "ActionSet"
+                    }
+                ],
+                "type": "AdaptiveCard",
+                "version": "1.3"
+            },
+            "title": "Action.ShowCard",
+            "type": "Action.ShowCard"
+        }
+    ],
+    "body": [
+        {
+            "height": "stretch",
+            "items": [
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "1",
+                    "isRequired": true,
+                    "isVisible": true,
+                    "label": "Hello this is label",
+                    "type": "Input.Date"
+                },
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "3",
+                    "isRequired": true,
+                    "isVisible": true,
+                    "label": "This is label",
+                    "type": "Input.Time"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "1",
+                                "3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "2",
+                    "type": "ActionSet"
+                }
+            ],
+            "type": "Container"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test1",
+                    "label": "Input Text"
+                }
+            ],
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test3",
+                    "label": "Input Text"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "test3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "ac2",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test4",
+                    "label": "Input Text"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "test4"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "ac3",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.3"
+}
+

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
@@ -46,7 +46,7 @@ class ACSFillerSpaceManager {
     private var paddingSet: NSHashTable<NSView>
     private var paddingConstraints: [NSLayoutConstraint]
     // This will be used only when all stretchable views are hidden and the card can't shrink to take up remaining space
-    private weak var lastPadding: SpacingView?
+    private weak var lastStretchableView: StretchableView?
     
     init() {
         paddingMap = NSMapTable<NSView, NSMutableArray>(keyOptions: .weakMemory, valueOptions: .strongMemory)
@@ -161,14 +161,15 @@ class ACSFillerSpaceManager {
         return spaceView
     }
     
-    func addLastPadding() -> NSView {
-        let spacer = SpacingView(frame: .zero)
-        lastPadding = spacer
-        lastPadding?.isHidden = true
-        return spacer
+    func addLastStretchableView(for view: ACRContentStackView) {
+        let stretchableView = StretchableView()
+        ACSFillerSpaceManager.configureHugging(view: stretchableView)
+        lastStretchableView = stretchableView
+        lastStretchableView?.isHidden = true
+        view.addArrangedSubview(stretchableView)
     }
     
     func toggleLastPaddingVisibility(isHidden: Bool) {
-        lastPadding?.isHidden = isHidden
+        lastStretchableView?.isHidden = isHidden
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
@@ -169,7 +169,7 @@ class ACSFillerSpaceManager {
         view.addArrangedSubview(stretchableView)
     }
     
-    func toggleLastPaddingVisibility(isHidden: Bool) {
+    func toggleLastStretchableViewVisibility(isHidden: Bool) {
         lastStretchableView?.isHidden = isHidden
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
@@ -45,6 +45,8 @@ class ACSFillerSpaceManager {
     private var stretchableViews: [NSValue]
     private var paddingSet: NSHashTable<NSView>
     private var paddingConstraints: [NSLayoutConstraint]
+    // This will be used only when all stretchable views are hidden and the card can't shrink to take up remaining space
+    private weak var lastPadding: SpacingView?
     
     init() {
         paddingMap = NSMapTable<NSView, NSMutableArray>(keyOptions: .weakMemory, valueOptions: .strongMemory)
@@ -157,5 +159,16 @@ class ACSFillerSpaceManager {
             return nil
         }
         return spaceView
+    }
+    
+    func addLastPadding() -> NSView {
+        let spacer = SpacingView(frame: .zero)
+        lastPadding = spacer
+        lastPadding?.isHidden = true
+        return spacer
+    }
+    
+    func toggleLastPaddingVisibility(isHidden: Bool) {
+        lastPadding?.isHidden = isHidden
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
@@ -14,7 +14,7 @@ import AppKit
     func visibilityManager(hideView view: NSView)
     func visibilityManager(unhideView view: NSView)
     func visibilityManagerAllStretchableViewsHidden() -> Bool
-    func visibilityManagerSetLastPaddingView(isHidden: Bool)
+    func visibilityManagerSetLastStretchableView(isHidden: Bool)
 }
 
 class ACSVisibilityManager {
@@ -169,7 +169,7 @@ class ACSVisibilityManager {
         }
     }
     
-    func changeVisibilityOfLastPadding(isHidden: Bool) {
-        fillerSpaceManager.toggleLastPaddingVisibility(isHidden: isHidden)
+    func changeVisibilityOfLastStretchableView(isHidden: Bool) {
+        fillerSpaceManager.toggleLastStretchableViewVisibility(isHidden: isHidden)
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSVisibilityManager.swift
@@ -13,6 +13,8 @@ import AppKit
 @objc protocol ACSVisibilityManagerFacade {
     func visibilityManager(hideView view: NSView)
     func visibilityManager(unhideView view: NSView)
+    func visibilityManagerAllStretchableViewsHidden() -> Bool
+    func visibilityManagerSetLastPaddingView(isHidden: Bool)
 }
 
 class ACSVisibilityManager {
@@ -165,5 +167,9 @@ class ACSVisibilityManager {
             }
             self.changeVisiblityOfAssociatedViews(hostView: viewToBeUnhidden, visibilityValue: false, contentStackView: hostView)
         }
+    }
+    
+    func changeVisibilityOfLastPadding(isHidden: Bool) {
+        fillerSpaceManager.toggleLastPaddingVisibility(isHidden: isHidden)
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -55,6 +55,7 @@ class AdaptiveCardRenderer {
         }
         rootView.delegate = actionDelegate
         rootView.resolverDelegate = resourceResolver
+        rootView.setMinimumHeight(card.getMinHeight())
         if card.getVersion() == "1.3", !config.supportsSchemeV1_3 {
             logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
         }
@@ -90,7 +91,6 @@ class AdaptiveCardRenderer {
         // add selectAction
         rootView.setupSelectAction(card.getSelectAction(), rootView: rootView)
         rootView.setupSelectActionAccessibility(on: rootView, for: card.getSelectAction())
-        rootView.setMinimumHeight(card.getMinHeight())
         
         if let backgroundImage = card.getBackgroundImage(), let url = backgroundImage.getUrl() {
             rootView.setupBackgroundImageProperties(backgroundImage)
@@ -98,7 +98,7 @@ class AdaptiveCardRenderer {
         }
         
         if heightSupport {
-            rootView.configureLayoutAndVisibility(card.getVerticalContentAlignment(), minHeight: card.getMinHeight(), heightType: card.getHeight(), type: .adaptiveCard)
+            rootView.configureLayoutAndVisibility(card.getVerticalContentAlignment(), minHeight: card.getMinHeight(), heightType: card.getHeight(), type: .adaptiveCard, isRootMinHeightAvailable: rootView.isMinHeightAvailable)
         }
         rootView.appearance = NSAppearance.getAppearance(isDark: config.isDarkMode)
         rootView.dispatchResolveRequests()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -24,7 +24,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: columnView, with: hostConfig, element: element, parentElement: column)
         }
         
-        columnView.configureLayoutAndVisibility(column.getVerticalContentAlignment(), minHeight: column.getMinHeight(), heightType: column.getHeight(), type: .column)
+        columnView.configureLayoutAndVisibility(column.getVerticalContentAlignment(), minHeight: column.getMinHeight(), heightType: column.getHeight(), type: .column, isRootMinHeightAvailable: rootView.isMinHeightAvailable)
         
         if let backgroundImage = column.getBackgroundImage(), let url = backgroundImage.getUrl() {
             columnView.setupBackgroundImageProperties(backgroundImage)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -96,7 +96,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
                 }
             }
         }
-        columnSetView.configureLayoutAndVisibility(columnSet.getVerticalContentAlignment(), minHeight: columnSet.getMinHeight(), heightType: columnSet.getHeight(), type: .columnSet)
+        columnSetView.configureLayoutAndVisibility(columnSet.getVerticalContentAlignment(), minHeight: columnSet.getMinHeight(), heightType: columnSet.getHeight(), type: .columnSet, isRootMinHeightAvailable: rootView.isMinHeightAvailable)
         return columnSetView
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -26,7 +26,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.updateLayoutForSeparatorAndAlignment(view: view, element: element, parentView: containerView, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: element, parentElement: container)
         }
-        containerView.configureLayoutAndVisibility(container.getVerticalContentAlignment(), minHeight: container.getMinHeight(), heightType: container.getHeight(), type: .container)
+        containerView.configureLayoutAndVisibility(container.getVerticalContentAlignment(), minHeight: container.getMinHeight(), heightType: container.getHeight(), type: .container, isRootMinHeightAvailable: rootView.isMinHeightAvailable)
         containerView.wantsLayer = true
         return containerView
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -68,7 +68,7 @@ class ACRColumnSetView: ACRContentStackView {
         }
     }
     
-    override func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType) {
+    override func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType, isRootMinHeightAvailable: Bool) {
         self.applyVisibilityToSubviews()
         self.setMinimumHeight(minHeight)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -334,8 +334,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         
         // when minheight constraint is applied and all views present have height auto it might cause these views to have ambiguous constraints, hence adding a padding at the end of stackView
         if self.hasStretchableView, let minHeight = minHeight?.intValue, (minHeight > 0 || isRootMinHeightAvailable) {
-            let padding = visibilityManager.fillerSpaceManager.addLastPadding()
-            self.addArrangedSubview(padding)
+            visibilityManager.fillerSpaceManager.addLastStretchableView(for: self)
         }
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -5,7 +5,7 @@ protocol ACRContentHoldingViewProtocol {
     func addArrangedSubview(_ subview: NSView)
     func insertArrangedSubview(_ view: NSView, at insertionIndex: Int)
     func updateLayoutAndVisibilityOfRenderedView(_ renderedView: NSView, acoElement acoElem: ACSBaseCardElement, separator: SpacingView?, rootView: ACRView?)
-    func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType)
+    func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType, isRootMinHeightAvailable: Bool)
     func applyPadding(_ padding: CGFloat)
 }
 
@@ -316,7 +316,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     /// activation constraint all at once is more efficient than activating
     /// constraints one by one.
     
-    func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType) {
+    func configureLayoutAndVisibility(_ verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?, heightType: ACSHeightType, type: ACSCardElementType, isRootMinHeightAvailable: Bool) {
         self.verticalContentAlignment = verticalContentAlignment
         self.applyVisibilityToSubviews()
         if self.shouldAddPadding(self.hasStretchableView) {
@@ -331,6 +331,12 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         }
         self.setMinimumHeight(minHeight)
         visibilityManager.fillerSpaceManager.activateConstraintsForPadding()
+        
+        // when minheight constraint is applied and all views present have height auto it might cause these views to have ambiguous constraints, hence adding a padding at the end of stackView
+        if self.hasStretchableView, let minHeight = minHeight?.intValue, (minHeight > 0 || isRootMinHeightAvailable) {
+            let padding = visibilityManager.fillerSpaceManager.addLastPadding()
+            self.addArrangedSubview(padding)
+        }
     }
     
     private func setupTrackingArea() {
@@ -531,6 +537,14 @@ extension ACRContentStackView: ACSVisibilityManagerFacade {
     
     func visibilityManager(unhideView view: NSView) {
         self.unhideView(view)
+    }
+    
+    func visibilityManagerAllStretchableViewsHidden() -> Bool {
+        return !visibilityManager.fillerSpaceManager.hasPadding()
+    }
+    
+    func visibilityManagerSetLastPaddingView(isHidden: Bool) {
+        visibilityManager.changeVisibilityOfLastPadding(isHidden: isHidden)
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -542,8 +542,8 @@ extension ACRContentStackView: ACSVisibilityManagerFacade {
         return !visibilityManager.fillerSpaceManager.hasPadding()
     }
     
-    func visibilityManagerSetLastPaddingView(isHidden: Bool) {
-        visibilityManager.changeVisibilityOfLastPadding(isHidden: isHidden)
+    func visibilityManagerSetLastStretchableView(isHidden: Bool) {
+        visibilityManager.changeVisibilityOfLastStretchableView(isHidden: isHidden)
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -11,6 +11,7 @@ class ACRView: ACRColumnView {
     private (set) var imageViewMap: [String: [ImageHoldingView]] = [:]
     private (set) var renderedShowCards: [NSView] = []
     private (set) var initialLayoutDone = false
+    private (set) var isMinHeightAvailable = false
     private var currentFocusedActionElement: NSCell?
     private var isLayoutDoneOnShowCard = false
     private var focusedElementOnHideError: NSView?
@@ -98,6 +99,13 @@ class ACRView: ACRColumnView {
         focusedElementOnHideError = currentFocussedView
     }
     
+    override func setMinimumHeight(_ height: NSNumber?) {
+        super.setMinimumHeight(height)
+        if let height = height?.intValue, height > 0 {
+            isMinHeightAvailable = true
+        }
+    }
+    
     private func submitCardInputs(actionView: NSView, dataJSON: String?, associatedInputs: Bool) {
         var dict = [String: Any]()
         
@@ -168,6 +176,13 @@ class ACRView: ACRColumnView {
                 } else {
                     facade.visibilityManager(unhideView: toggleView)
                 }
+            }
+            
+            // toggle the last padding if all other
+            if facade?.visibilityManagerAllStretchableViewsHidden() == true {
+                facade?.visibilityManagerSetLastPaddingView(isHidden: !isHide)
+            } else {
+                facade?.visibilityManagerSetLastPaddingView(isHidden: isHide)
             }
         }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -179,7 +179,7 @@ class ACRView: ACRColumnView {
             }
             
             // toggle the last padding if all other
-            if facade?.visibilityManagerAllStretchableViewsHidden() == true {
+            if facade?.visibilityManagerAllStretchableViewsHidden() ?? false {
                 facade?.visibilityManagerSetLastPaddingView(isHidden: !isHide)
             } else {
                 facade?.visibilityManagerSetLastPaddingView(isHidden: isHide)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -180,9 +180,9 @@ class ACRView: ACRColumnView {
             
             // toggle the last padding if all other
             if facade?.visibilityManagerAllStretchableViewsHidden() ?? false {
-                facade?.visibilityManagerSetLastPaddingView(isHidden: !isHide)
+                facade?.visibilityManagerSetLastStretchableView(isHidden: !isHide)
             } else {
-                facade?.visibilityManagerSetLastPaddingView(isHidden: isHide)
+                facade?.visibilityManagerSetLastStretchableView(isHidden: isHide)
             }
         }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
@@ -129,4 +129,66 @@ class AdaptiveCardsTests: XCTestCase {
             testRetainCycles()
         }
     }
+    
+    func testToggleVisibilityWithLastStretchableView() {
+        self.measure {
+            // Put the code you want to measure the time of here.
+            renderCardWithToggleVisibilityAndMinHeight()
+        }
+    }
+    
+    func testToggleVisibilityWithoutLastStretchableView() {
+        self.measure {
+            renderCardWithToggleVisibilityWithoutMinHeight()
+        }
+    }
+        
+    func renderCardWithToggleVisibilityAndMinHeight() {
+        let bundle = Bundle(for: type(of: self))
+        let filename = "ToggleVisibilityWithMinHeight.json"
+        
+        let dataAsset = NSDataAsset(name: filename, bundle: bundle)?.data
+        guard let data = dataAsset else { return }
+        let jsonString = String(data: data, encoding: .utf8)!
+        
+        let hostConfigData = NSDataAsset(name: "HostConfig.json", bundle: bundle)!.data
+        let hostConfigJSON = String(data: hostConfigData, encoding: .utf8)!
+        let hostConfig = try! AdaptiveCard.parseHostConfig(from: hostConfigJSON).get()
+        
+        weak var weakCard1: NSView?
+        for _ in 0..<50 {
+            let card = AdaptiveCard.from(jsonString: jsonString).getAdaptiveCard()!
+            var blockExecuted = false
+            autoreleasepool {
+                let cardView = AdaptiveCard.render(card: card, with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
+                weakCard1?.addSubview(cardView)
+                blockExecuted = true
+            }
+            
+            XCTAssertTrue(blockExecuted)
+        }
+    }
+    
+    func renderCardWithToggleVisibilityWithoutMinHeight() {
+        let bundle = Bundle(for: type(of: self))
+        let filename = "ToggleVisibilityWithoutMinHeight.json"
+        
+        let dataAsset = NSDataAsset(name: filename, bundle: bundle)?.data
+        guard let data = dataAsset else { return }
+        let jsonString = String(data: data, encoding: .utf8)!
+        
+        let hostConfigData = NSDataAsset(name: "HostConfig.json", bundle: bundle)!.data
+        let hostConfigJSON = String(data: hostConfigData, encoding: .utf8)!
+        let hostConfig = try! AdaptiveCard.parseHostConfig(from: hostConfigJSON).get()
+        
+        weak var weakCard1: NSView?
+        for _ in 0..<50 {
+            let card = AdaptiveCard.from(jsonString: jsonString).getAdaptiveCard()!
+            
+            autoreleasepool {
+                let cardView = AdaptiveCard.render(card: card, with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
+                weakCard1?.addSubview(cardView)
+            }
+        }
+    }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -19,12 +19,12 @@ class ColumnSetRendererTests: XCTestCase {
         
         let autoColumnSet = FakeColumnSet.make(columns: columns, heightType: .auto)
         let rootAutoView = renderColumnSetInsideContainerView(FakeContainer.make(elemType: .container, minHeight: 200, items: [autoColumnSet]))
-        XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.capacity, 2)
+        XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.capacity, 3)
         XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.first?.contentHuggingPriority(for: .vertical), NSLayoutConstraint.Priority.defaultLow)
         
         let stretchColumnSet = FakeColumnSet.make(columns: columns, heightType: .stretch)
         let rootStretchView = renderColumnSetInsideContainerView(FakeContainer.make(elemType: .container, minHeight: 200, items: [stretchColumnSet]))
-        XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.capacity, 1)
+        XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.capacity, 2)
         XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.first?.contentHuggingPriority(for: .vertical), kFillerViewLayoutConstraintPriority)
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -23,12 +23,12 @@ class ContainerRendererTests: XCTestCase {
     func testHeightProperty() {
         let autoContainer = FakeContainer.make(elemType: .container, heightType: .auto)
         let rootAutoView = renderContainerView(FakeContainer.make(elemType: .container, minHeight: 200, items: [autoContainer]))
-        XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.capacity, 2)
+        XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.capacity, 3)
         XCTAssertEqual(rootAutoView.stackView.arrangedSubviews.first?.contentHuggingPriority(for: .vertical), NSLayoutConstraint.Priority.defaultLow)
         
         let stretchContainer = FakeContainer.make(elemType: .container, heightType: .stretch)
         let rootStretchView = renderContainerView(FakeContainer.make(elemType: .container, minHeight: 200, items: [stretchContainer]))
-        XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.capacity, 1)
+        XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.capacity, 2)
         XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.first?.contentHuggingPriority(for: .vertical), kFillerViewLayoutConstraintPriority)
     }
     


### PR DESCRIPTION
## Description
Toggle Visibility does not work in certain scenarios where there is a min height requirement and all the stretcable views are hidden, forcing a view with fixed size to stretch

At the very least please describe the issue you are addressing, and what your fix entails. 

| Previous | Current    | 
| :---:   | :---: |
| ![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/78855675/202911512-af64a58f-44ff-4442-9d3c-6b08eb63a9de.gif)  |  ![fix-hide-spike](https://user-images.githubusercontent.com/78855675/202911549-5c0c0415-fbbb-44cd-a709-5af01f17ad5b.gif)  |
| ![image](https://user-images.githubusercontent.com/78855675/202967469-33b1a2a0-6c72-4c29-be08-a8de7dccb824.png) | ![image](https://user-images.githubusercontent.com/78855675/202967506-df84fa6a-c52d-4633-85f8-c610a9e25d0f.png) |


## Sample Card

```
{
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "actions": [
        {
            "title": "OK",
            "type": "Action.Submit"
        }
    ],
    "body": [
        {
            "errorMessage": "error message error message error message error message ",
            "height": "stretch",
            "id": "1",
            "isRequired": true,
            "label": "Hello this is label",
            "type": "Input.Date",
            "isVisible": true
        },
        {
            "errorMessage": "error message error message error message error message ",
            "height": "stretch",
            "id": "3",
            "isRequired": true,
            "label": "This is label",
            "type": "Input.Time",
            "isVisible": true
        },
        {
            "actions": [
                {
                    "targetElements": [
                        "1",
                        "3"
                    ],
                    "title": "Action.ToggleVisibility",
                    "type": "Action.ToggleVisibility"
                }
            ],
            "id": "2",
            "type": "ActionSet"
        }
    ],
    "minHeight": "400px",
    "type": "AdaptiveCard",
    "version": "1.3"
}
```

## How Verified
How you verified the fix, including one or all of the following: 
1. Tested multiple different scenarios involving this case
2. Ran older unit tests and BTP to catch regression
