### PR TITLE
Add new protocol at ImageResourceHandlerView for Image setup

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/ResourceResolverProtocol.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/ResourceResolverProtocol.swift
@@ -4,6 +4,7 @@ import AppKit
 public protocol ImageResourceHandlerView: NSView {
     func setImage(_ image: NSImage, for url: String)
     func setImage(_ image: NSImage, forURLsContaining matcher: @escaping (String) -> Bool)
+    func dispatchImageResolveRequests()
 }
 
 protocol ImageHoldingView: NSView {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -101,7 +101,7 @@ class AdaptiveCardRenderer {
             rootView.configureLayoutAndVisibility(verticalContentAlignment: card.getVerticalContentAlignment(), minHeight: card.getMinHeight(), isBackgroundImageAvailable: !(card.getBackgroundImage()?.getUrl()?.isEmpty ?? true))
         }
         rootView.appearance = NSAppearance.getAppearance(isDark: config.isDarkMode)
-        rootView.dispatchResolveRequests()
+        rootView.dispatchImageResolveRequests()
         return rootView
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -74,12 +74,6 @@ class ACRView: ACRColumnView {
         return resolverDelegate?.adaptiveCard(self, dimensionsForImageWith: url)
     }
     
-    func dispatchResolveRequests() {
-        for url in imageViewMap.keys {
-            resolverDelegate?.adaptiveCard(self, requestImageFor: url)
-        }
-    }
-    
     func resetKeyboardFocus() {
         if isLayoutDoneOnShowCard, let lastFocusedElement = currentFocusedActionElement {
             lastFocusedElement.controlView?.setAccessibilityFocused(true)
@@ -252,6 +246,12 @@ extension ACRView: ImageResourceHandlerView {
             self.renderedShowCards
                 .compactMap { $0 as? ImageResourceHandlerView }
                 .forEach { $0.setImage(image, forURLsContaining: matcher) }
+        }
+    }
+    
+    func dispatchImageResolveRequests() {
+        for url in imageViewMap.keys {
+            resolverDelegate?.adaptiveCard(self, requestImageFor: url)
         }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -49,7 +49,7 @@ class ACRViewTests: XCTestCase {
         view.registerImageHandlingView(imageView2, for: "test2")
         view.registerImageHandlingView(imageView3, for: "test3")
         
-        view.dispatchResolveRequests()
+        view.dispatchImageResolveRequests()
         
         XCTAssertEqual(fakeResourceResolver.calledCount, 3)
         wait(for: [imageView1.expectation!, imageView2.expectation!, imageView3.expectation!], timeout: 0.2)
@@ -66,7 +66,7 @@ class ACRViewTests: XCTestCase {
         view.registerImageHandlingView(FakeImageHoldingView(), for: "test")
         view.registerImageHandlingView(FakeImageHoldingView(), for: "test2")
         
-        view.dispatchResolveRequests()
+        view.dispatchImageResolveRequests()
         
         XCTAssertEqual(fakeResourceResolver.calledCount, 2)
         XCTAssertEqual(fakeResourceResolver.calledURLs.count, 2)
@@ -87,7 +87,7 @@ class ACRViewTests: XCTestCase {
         view.registerImageHandlingView(imageView2, for: "test")
         view.registerImageHandlingView(imageView3, for: "test")
         
-        view.dispatchResolveRequests()
+        view.dispatchImageResolveRequests()
         
         XCTAssertEqual(fakeResourceResolver.calledCount, 1)
         wait(for: [imageView1.expectation!, imageView2.expectation!, imageView3.expectation!], timeout: 0.2)


### PR DESCRIPTION
## Changes
- Add new Image setup protocol at ImageResourceHandlerView
- This change help in calling set the image from the client side as needed, While there are many adaptive cards in table or collection view.

## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
