### PR TITLE
Fix: ActionSet height gets ambigus with stretch containers

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Container-stretch-with-toggleaction.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Container-stretch-with-toggleaction.json
@@ -1,0 +1,35 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "Container",
+            "id": "1",
+            "style": "attention",
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "id": "2",
+            "style": "accent",
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "id": "3",
+            "style": "good"
+        },
+        {
+            "type": "ActionSet",
+            "actions": [
+                {
+                    "type": "Action.ToggleVisibility",
+                    "title": "Action.ToggleVisibility",
+                    "targetElements": [ "2"]
+                }
+            ]
+        }
+    ],
+    "minHeight": "400px"
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Container-toggle-stretchview.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Container-toggle-stretchview.json
@@ -1,0 +1,35 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "Container",
+            "style": "accent",
+            "height": "stretch",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "New TextBlock",
+                    "wrap": true,
+                    "height": "stretch",
+                    "id": "1",
+                    "isVisible": false
+                }
+            ]
+        },
+        {
+            "type": "ActionSet",
+            "actions": [
+                {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": [
+                        "1"
+                    ],
+                    "title": "Action.ToggleVisibility"
+                }
+            ]
+        }
+    ],
+    "minHeight": "300px"
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -27,6 +27,9 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: element, parentElement: container)
         }
         containerView.configureLayoutAndVisibility(verticalContentAlignment: container.getVerticalContentAlignment(), minHeight: container.getMinHeight())
+        if container.getHeight() == .stretch {
+            containerView.setStretchableHeight()
+        }
         containerView.wantsLayer = true
         return containerView
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -20,6 +20,12 @@ class ContainerRendererTests: XCTestCase {
         XCTAssertEqual(containerView.layer?.backgroundColor, nil)
     }
     
+    func testStretchableEmptyContainer() {
+        let fakeStretchContainer = FakeContainer.make(elemType: .container, heightType: .stretch)
+        let stretchContainer = renderContainerView(fakeStretchContainer)
+        XCTAssertEqual(stretchContainer.arrangedSubviews.capacity, 1)
+    }
+    
     func testHeightProperty() {
         let autoContainer = FakeContainer.make(elemType: .container, heightType: .auto)
         let rootAutoView = renderContainerView(FakeContainer.make(elemType: .container, minHeight: 200, items: [autoContainer]))
@@ -34,14 +40,14 @@ class ContainerRendererTests: XCTestCase {
     }
     
     func testRendererSetsVerticalContentAlignment() {
-        container = .make(verticalContentAlignment: .top)
+        container = .make(verticalContentAlignment: .top, items: [FakeTextBlock.make()])
         // Removing this since we don't need subviews to have padding to have explicit width
-//        var containerView = renderContainerView(container)
-//        // For HeightType Property we have add stretchable view. so it will increase count for subviews.
-//        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 1)
+        var containerView = renderContainerView(container)
+        // For HeightType Property we have add stretchable view. so it will increase count for subviews.
+        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 2)
         
         container = .make(verticalContentAlignment: .bottom, items: [FakeTextBlock.make()])
-        var containerView = renderContainerView(container)
+        containerView = renderContainerView(container)
         // since we removed padding view all together and replaced with lastPadding but use paddingView for vertical content alignment this has changed
         // SpaceView 1
         XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 3)
@@ -92,24 +98,14 @@ class ContainerRendererTests: XCTestCase {
     }
     
     func testPaddingWhenContainerEmptyWithoutStyle() {
-        // No padding added
         let containerView = renderContainerView(FakeContainer.make(style: .none, elemType: .container, visible: true))
         XCTAssertEqual(containerView.stackView.arrangedSubviews.count, 0)
-        
-        
-        // Removing this test since now we don't need to add a padding to make containers visible
-        //Added padding
-//        containerView = renderContainerView(FakeContainer.make(style: .default, elemType: .container, visible: true))
-//        XCTAssertEqual(containerView.stackView.arrangedSubviews.count, 1)
     }
     
     func testRendersItems() {
-        /// TO DO: Test Failed due to Height Property which is not yet add in InputToggleView
-        /// we will add test case, once done with input toggle
-        
-        /*container = .make(items: [FakeInputToggle.make()])
+        container = .make(items: [FakeInputToggle.make()])
         let containerView = renderContainerView(container)
-        XCTAssertEqual(containerView.arrangedSubviews.count, 1)*/
+        XCTAssertEqual(containerView.arrangedSubviews.count, 2)
     }
     
     private func renderContainerView(_ element: ACSContainer) -> ACRContainerView {


### PR DESCRIPTION
## Related Issue Changes
- update container file
- update and add unit test

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.
**Before**    |  **After**
:-------------------------:|:-------------------------:
<img width="444" alt="Screenshot 2023-02-06 at 5 38 27 PM" src="https://user-images.githubusercontent.com/105660080/217056280-5f6080e1-110a-4f8b-81a9-f7832308c61f.png">|<img width="445" alt="Screenshot 2023-02-06 at 5 37 44 PM" src="https://user-images.githubusercontent.com/105660080/217056291-c50204bc-db62-4524-9e07-dc6e56ee0dcb.png">

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
