### PR TITLE
[macOS] inline button stretch fix without title

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 		088C673C2615C2B00070186C /* ACRContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088C673B2615C2B00070186C /* ACRContentStackView.swift */; };
 		088F716226A9560600C52C06 /* ActionToggleVisibilityRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F716126A9560600C52C06 /* ActionToggleVisibilityRenderer.swift */; };
 		088F716526A9925400C52C06 /* SpacingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F716426A9925400C52C06 /* SpacingView.swift */; };
-		089DC88025B6C8AE00626E8F /* libAdaptiveCards-shared.a in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 08E403B125B46A2600C2092A /* libAdaptiveCards-shared.a */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		089DC88025B6C8AE00626E8F /* libAdaptiveCards-shared.a in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 08E403B125B46A2600C2092A /* libAdaptiveCards-shared.a */; };
 		089DC8D725B856FA00626E8F /* BridgeConverter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 089DC8D625B856FA00626E8F /* BridgeConverter.mm */; };
 		08A12EE326987B5C00490977 /* ACSExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A12EE226987B5C00490977 /* ACSExtensions.swift */; };
 		08B5F91125C924F400A7D37A /* TextBlockRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5F91025C924F400A7D37A /* TextBlockRenderer.swift */; };

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
@@ -62,7 +62,7 @@ class ACRSingleLineInputTextView: NSView {
         let button = ACRButton(actionElement: element.getInlineAction(), iconPlacement: hostConfig.getActions()?.iconPlacement, buttonConfig: renderConfig.buttonConfig, style: .inline)
         button.translatesAutoresizingMaskIntoConstraints = false
         let attributedString: NSMutableAttributedString
-        attributedString = NSMutableAttributedString(string: button.title.isEmpty ? "Action" : button.title)
+        attributedString = NSMutableAttributedString(string: button.title.isEmpty ? "" : button.title)
         if let colorHex = hostConfig.getForegroundColor(style, color: .default, isSubtle: true), let textColor = ColorUtils.color(from: colorHex) {
             attributedString.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedString.length))
         }
@@ -107,7 +107,6 @@ class ACRSingleLineInputTextView: NSView {
         textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
         if element.getInlineAction() != nil {
             inlineButton.leadingAnchor.constraint(equalTo: textView.trailingAnchor, constant: 8.0).isActive = true
-            inlineButton.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
             inlineButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
             inlineButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
             inlineButton.widthAnchor.constraint(lessThanOrEqualTo: textView.widthAnchor, multiplier: 0.5).isActive = true

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
@@ -23,6 +23,10 @@ extension CALayer {
 }
 
 open class FlatButton: NSButton, CALayerDelegate {
+    struct Constants {
+        static let buttonEmptyPadding: CGFloat = 4
+    }
+    
     internal var containerLayer = CALayer()
     internal var iconLayer = CAShapeLayer()
     internal var alternateIconLayer = CAShapeLayer()
@@ -190,6 +194,8 @@ open class FlatButton: NSButton, CALayerDelegate {
         totalWidth += showsIcon && (imagePosition == .imageLeft || imagePosition == .imageRight) ? iconImageSize.width + horizontalInternalSpacing : 0
         totalWidth += showsChevron ? chevronImageSize.width + horizontalInternalSpacing : 0
         totalHeight += (imagePosition == .imageBelow || imagePosition == .imageAbove) ? iconImageSize.height : 0
+        // If button is completely empty, add some spacing
+        totalWidth += (title.isEmpty && !showsIcon && !showsChevron) ? (totalHeight - contentInsets.left - contentInsets.right + Constants.buttonEmptyPadding ) : 0
         return NSSize(width: totalWidth, height: totalHeight)
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRButtonTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRButtonTests.swift
@@ -96,4 +96,10 @@ class ACRButtonTests: XCTestCase {
         button = ACRButton(frame: .zero, wantsChevron: false, wantsIcon: false, iconPosition: .imageLeft, style: .default, buttonConfig: .default)
         XCTAssertNotNil(button.chevronDownIcon)
     }
+    
+    func testEmptyButtonSize() {
+        button = ACRButton(frame: .zero, wantsChevron: false, wantsIcon: false, iconPosition: .imageAbove, style: .default, buttonConfig: .default)
+        button.title = ""
+        XCTAssertEqual(button.intrinsicContentSize.width, button.intrinsicContentSize.height + ACRButton.Constants.buttonEmptyPadding)
+    }
 }


### PR DESCRIPTION
## Description

Fixed inline button getting stretched without title

## Sample Card
```{ "$schema": "http://adaptivecards.io/schemas/adaptive-card.json", "type": "AdaptiveCard", "version": "1.3", "body": [ { "type": "Input.Text", "id": "iconInlineActionId", "label": "Text input with an inline action", "inlineAction": { "type": "Action.Submit", "iconUrl": "https://adaptivecards.io/content/send.png" } }, { "type": "Input.Text", "label": "Text input with an inline action with no icon", "id": "textInlineActionId", "inlineAction": { "type": "Action.OpenUrl", "title": "", "url": "https://adaptivecards.io" } }, { "type": "TextBlock", "text": "New TextBlock", "wrap": true }, { "type": "ActionSet", "actions": [ { "type": "Action.Submit", "iconUrl": "https://adaptivecards.io/content/send.png" } ] }, { "type": "ActionSet", "actions": [ { "type": "Action.Submit", "title": "" } ] } ] }```

ScreenShot:
Before: 
<img width="433" alt="Screenshot 2023-02-06 at 8 35 32 PM" src="https://user-images.githubusercontent.com/78855675/217136975-04e6e40b-00e2-45c8-b997-5b1fc67c4d60.png">
After:
<img width="433" alt="Screenshot 2023-02-06 at 8 39 26 PM" src="https://user-images.githubusercontent.com/78855675/217137049-5d4bf639-e84b-4852-a28d-7c86e237a511.png">


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
