### PR TITLE
[Windows] Placeholder text for input text not wrapping if the text is…

### DIFF
--- a/source/qml/Samples/QmlVisualizer/AdaptiveCardQml/MultiLineTextInputRender.qml
+++ b/source/qml/Samples/QmlVisualizer/AdaptiveCardQml/MultiLineTextInputRender.qml
@@ -90,7 +90,29 @@ Rectangle {
             }
             font.pixelSize: CardConstants.inputFieldConstants.pixelSize
             text: _mEscapedValueString
-            placeholderText: activeFocus ? '' : _mEscapedPlaceHolderString
+            //placeholderText: activeFocus ? '' : _mEscapedPlaceHolderString
+
+                property alias customPlaceholderText: innerPlaceholderText.text
+                property alias customPlaceholderTextColor: innerPlaceholderText.color
+
+                customPlaceholderText: activeFocus || _inputtextTextField.text ? '' : _mEscapedPlaceHolderString
+                //customPlaceholderTextColor: "#aaa" //this property alias doesn't seem to work, can swap it out for a normal property maybe
+
+                Text{
+                    id: innerPlaceholderText
+                    visible: !_inputtextTextField.text
+                    font: _inputtextTextField.font
+                    anchors.leftMargin: _inputtextTextField.leftPadding
+                    anchors.rightMargin: _inputtextTextField.rightPadding
+                    anchors.topMargin: _inputtextTextField.topPadding
+                    anchors.bottomMargin: _inputtextTextField.bottomPadding
+                    anchors.fill: parent
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignTop
+                    wrapMode: _inputtextTextField.wrapMode
+                    color: "#aaa"
+                }
+
 
             background: Rectangle {
                 id: _multilinetextidTextFieldBackground


### PR DESCRIPTION
… too large

## Related Issue
[SPARK-399618](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-399618)

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
[Windows] Placeholder text for input text not wrapping if the text is too large

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
{
"type": "AdaptiveCard",
"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
"version": "1.3",
"body": [

{ "type": "Input.Text", "placeholder": "Enter phone numbers (currently only US numbers), separated by comma...............................................................wdjwjdkwjdkhwekjdhwkjhdkwhdkjw", "isMultiline": true, "id": "sms" }
]
}

## How Verified
![image](https://user-images.githubusercontent.com/94901239/221348548-30931f1a-66fc-428d-ad01-00d6201be152.png)

