### PR TITLE
macOS | Fix | Error message hidden on submit action

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorElementHiddenSelectAction.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorElementHiddenSelectAction.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "body": [
+        {
+            "type": "Input.Toggle",
+            "title": "New Input.Toggle New Input.ToggleNew Input.Toggle New Input.ToggleNew Input.Toggle",
+            "id": "toggle",
+            "value": "valueOff",
+            "valueOn": "valueOn",
+            "valueOff": "valueOff",
+            "wrap": true,
+            "label": "Label",
+            "isRequired": true,
+            "errorMessage": "Error Message"
+        },
+        {
+            "errorMessage": "Please Enter Some Valid Input",
+            "id": "inputText",
+            "isRequired": true,
+            "label": "Input Text",
+            "placeholder": "Placeholder text",
+            "type": "Input.Text"
+        },
+        {
+            "actions": [
+                {
+                    "style": "destructive",
+                    "targetElements": [
+                        "inputText"
+                    ],
+                    "title": "Text",
+                    "type": "Action.ToggleVisibility"
+                },
+                {
+                    "style": "destructive",
+                    "targetElements": [
+                        "toggle"
+                    ],
+                    "title": "Toggle",
+                    "type": "Action.ToggleVisibility"
+                }
+            ],
+            "type": "ActionSet"
+        },
+        {
+            "actions": [
+                {
+                    "style": "positive",
+                    "title": "Action.Submit",
+                    "type": "Action.Submit"
+                }
+            ],
+            "type": "ActionSet"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.3"
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
@@ -180,6 +180,10 @@ class ACRChoiceButton: NSView, NSTextFieldDelegate, InputHandlingViewProtocol {
         errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
+    func setShowError(_ value: Bool) {
+        self.shouldShowError = value
+    }
+    
     func setAccessibilityFocus() {
         button.setAccessibilityFocused(true)
         errorDelegate?.inputHandlingViewShouldAnnounceErrorMessage(self, message: accessibilityLabel())

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetCompactPopupButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetCompactPopupButton.swift
@@ -57,7 +57,6 @@ class ACRChoiceSetCompactPopupButton: NSPopUpButton, InputHandlingViewProtocol {
     
     func showError() {
         shouldShowError = true
-        errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
     func setAccessibilityFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCompactChoiceSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCompactChoiceSetView.swift
@@ -49,7 +49,7 @@ class ACRCompactChoiceSetView: NSView {
         self.rootview = rootview
         self.setupView()
         self.setupContraints()
-        self.rootview?.addInputHandler(choiceSetPopup)
+        self.rootview?.addInputHandler(self)
     }
     
     required init?(coder: NSCoder) {
@@ -141,6 +141,7 @@ extension ACRCompactChoiceSetView: InputHandlingViewProtocol {
     
     func showError() {
         choiceSetPopup.showError()
+        errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
     func setAccessibilityFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRInputToggleView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRInputToggleView.swift
@@ -118,7 +118,8 @@ extension ACRInputToggleView: InputHandlingViewProtocol {
     }
     
     func showError() {
-        self.choiceButton.showError()
+        self.choiceButton.setShowError(true)
+        errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
     func setAccessibilityFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
@@ -14,6 +14,7 @@ class ACRSingleLineInputTextView: NSView {
     private let style: ACSContainerStyle
     private let hostConfig: ACSHostConfig
     private weak var rootview: ACRView?
+    weak var errorDelegate: InputHandlingViewErrorDelegate?
     
     private var contentView = NSView()
     private (set) lazy var contentStackView: NSStackView = {
@@ -89,7 +90,7 @@ class ACRSingleLineInputTextView: NSView {
         self.addSubview(contentStackView)
         self.contentStackView.addArrangedSubview(contentView)
         self.contentView.addSubview(textView)
-        self.rootview?.addInputHandler(textView)
+        self.rootview?.addInputHandler(self)
         if element.getInlineAction() != nil {
             self.contentView.addSubview(inlineButton)
             self.setupInlineButton()
@@ -175,17 +176,9 @@ extension ACRSingleLineInputTextView: InputHandlingViewProtocol {
         return self.textView.isRequired
     }
     
-    weak var errorDelegate: InputHandlingViewErrorDelegate? {
-        get {
-            return self.textView.errorDelegate
-        }
-        set {
-            self.textView.errorDelegate = newValue
-        }
-    }
-    
     func showError() {
         self.textView.showError()
+        errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
     func setAccessibilityFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRSingleLineInputTextView.swift
@@ -14,7 +14,6 @@ class ACRSingleLineInputTextView: NSView {
     private let style: ACSContainerStyle
     private let hostConfig: ACSHostConfig
     private weak var rootview: ACRView?
-    weak var errorDelegate: InputHandlingViewErrorDelegate?
     
     private var contentView = NSView()
     private (set) lazy var contentStackView: NSStackView = {
@@ -156,6 +155,15 @@ class ACRSingleLineInputTextView: NSView {
     }
 }
 extension ACRSingleLineInputTextView: InputHandlingViewProtocol {
+    weak var errorDelegate: InputHandlingViewErrorDelegate? {
+        get {
+            return self.textView.errorDelegate
+        }
+        set {
+            self.textView.errorDelegate = newValue
+        }
+    }
+    
     var isErrorShown: Bool {
         return self.textView.isErrorShown
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextInputView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextInputView.swift
@@ -57,7 +57,6 @@ class ACRTextInputView: ACRTextField, InputHandlingViewProtocol {
     
     override func showError() {
         super.showError()
-        errorDelegate?.inputHandlingViewShouldShowError(self)
     }
     
     func setAccessibilityFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
@@ -185,7 +185,6 @@ class ACRTextView: NSTextView, SelectActionHandlingProtocol {
         alignment = .left
         isEditable = false
         backgroundColor = .clear
-        selectedTextAttributes = [.backgroundColor: NSColor.blue]
         linkTextAttributes = [
             .foregroundColor: config.foregroundColor,
             .underlineColor: config.underlineColor,

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputToggle.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputToggle.swift
@@ -74,6 +74,10 @@ class FakeInputToggle: ACSToggleInput {
         return visibility
     }
     
+    override func setIsVisible(_ value: Bool) {
+        visibility = value
+    }
+    
     override func getLabel() -> String? {
         return label
     }
@@ -107,9 +111,10 @@ class FakeInputToggle: ACSToggleInput {
     }
 }
 extension FakeInputToggle {
-    static func make(id: String? = "", title: String? = "", value: String = "false", valueOn: String = "true", valueOff: String = "false", wrap: Bool = false, isRequired: Bool = false, errorMessage: String? = "", label: String? = "", heightType: ACSHeightType = .auto) ->FakeInputToggle {
+    static func make(id: String? = "", title: String? = "", value: String = "false", valueOn: String = "true", valueOff: String = "false", wrap: Bool = false, isRequired: Bool = false, errorMessage: String? = "", label: String? = "", visibility: Bool = true, heightType: ACSHeightType = .auto) ->FakeInputToggle {
         let fakeInputToggle = FakeInputToggle()
         fakeInputToggle.id = id
+        fakeInputToggle.visibility = visibility
         fakeInputToggle.title = title
         fakeInputToggle.value = value
         fakeInputToggle.valueOn = valueOn

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
@@ -6,12 +6,28 @@ class InputToggleRendererTests: XCTestCase {
     private var hostConfig: FakeHostConfig!
     private var inputToggle: FakeInputToggle!
     private var inputToggleRenderer: InputToggleRenderer!
+    private var renderConfig: RenderConfig!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
         hostConfig = .make()
         inputToggle = .make()
         inputToggleRenderer = InputToggleRenderer()
+        renderConfig = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+    }
+    
+    func testErrorViewToggle() {
+        let title = "Hello world!"
+        inputToggle = .make(id: "id1", title: title, isRequired: true, visibility: false)
+        let fakeRoot = FakeRootView()
+        let container = FakeContainer.make(items: [inputToggle])
+        let containerView = ContainerRenderer.shared.render(element: container, with: hostConfig, style: .default, rootView: fakeRoot, parentView: fakeRoot, inputs: [], config: renderConfig)
+        guard let containerView = containerView as? ACRContainerView else { fatalError() }
+        guard let handlerView = fakeRoot.inputHandlers.first else { fatalError() }
+        XCTAssertEqual(handlerView.key, "id1")
+        XCTAssertTrue(handlerView.isHidden)
+        XCTAssertFalse(containerView.isErrorVisible(handlerView))
+        XCTAssertNotNil(containerView.getErrorTextField(for: handlerView))
     }
     
     func testRendererSetsTitle() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
@@ -64,6 +64,15 @@ class TextInputRendererTest: XCTestCase {
         XCTAssertEqual(inputTextField.textView.accessibilityValue(), "somevalue")
     }
     
+    func testSingleLineTextInputHandler() {
+        let valueString: String = "somevalue"
+        inputText = .make(value: valueString, isRequired: true)
+        let fakeRootView = FakeRootView()
+        let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: fakeRootView, parentView: fakeRootView, inputs: [], config: .default)
+        guard let inputTextField = view as? ACRSingleLineInputTextView else { fatalError() }
+        XCTAssertEqual(fakeRootView.inputHandlers.first as? ACRSingleLineInputTextView, inputTextField)
+    }
+    
     private func renderTextInput() -> ACRSingleLineInputTextView {
         let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRChoiceSetButtonTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRChoiceSetButtonTests.swift
@@ -22,6 +22,16 @@ class ACRChoiceSetButtontests: XCTestCase {
         XCTAssertNotNil(choiceButton)
     }
     
+    func testChoiceButtonSetShowError() {
+        //Test default initialsier
+        let choiceButton = ACRChoiceButton(renderConfig: renderConfig, buttonType: .switch, element: choiceSetInput, title: "Test")
+        XCTAssertNotNil(choiceButton)
+        choiceButton.setShowError(true)
+        XCTAssertTrue(choiceButton.isErrorShown)
+        choiceButton.setShowError(false)
+        XCTAssertFalse(choiceButton.isErrorShown)
+    }
+    
     func testCheckBoxButtonClick() {
         XCTAssertEqual(choiceCheckBoxButtonView.state, .off)
         choiceCheckBoxButtonView.button.performClick(nil)


### PR DESCRIPTION
- changes in ACRChoiceButton
- delegate method changes in Input.Toggle
- Input handler change in Input.Text
- add unit test
- ACRTextView regression line changes in ACL

**Before output** | **Changes output**
:-------------------------:|:-------------------------:
![before-error-message-acl](https://user-images.githubusercontent.com/105660080/230282628-d1b3bec8-f0f0-4326-91b4-cb7641651f85.gif) | ![after-error-message-acl](https://user-images.githubusercontent.com/105660080/230282659-220b6c70-3698-427d-adda-5ad473ef7687.gif)


## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
