### PR TITLE
[macOS] Fixed Date Time accepting values outside min max range

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/InvaidDefaultDateTimeSample.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/InvaidDefaultDateTimeSample.json
@@ -1,0 +1,28 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "Input.Date",
+            "id": "date",
+            "value": "2023-03-02",
+            "min": "2023-03-05",
+            "placeholder": "Enter a date",
+            "max": "2023-03-25"
+        },
+        {
+            "type": "Input.Time",
+            "id": "time4",
+            "min": "09:00",
+            "max": "17:00",
+            "value": "19:30"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Action.Submit"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -283,6 +283,10 @@ extension ACRDateField: NSPopoverDelegate {
 extension ACRDateField: ACRTextFieldDelegate {
     func acrTextFieldDidSelectClear(_ textField: ACRTextField) {
         selectedDate = nil
+        if isValid {
+            errorDelegate?.inputHandlingViewShouldHideError(self, currentFocussedView: iconImage)
+            textField.hideError()
+        }
     }
 }
 
@@ -303,8 +307,16 @@ extension ACRDateField: InputHandlingViewProtocol {
     }
     
     var isValid: Bool {
-        // TODO: Add min and max date checks too
-        return isBasicValidationsSatisfied
+        guard isBasicValidationsSatisfied else { return false }
+        if let selectedDate = selectedDate {
+            if let minDateValue = minDateValue, let minDate = dateFormatter.date(from: minDateValue), selectedDate < minDate {
+                return false
+            }
+            if let maxDateValue = maxDateValue, let maxDate = dateFormatter.date(from: maxDateValue), selectedDate > maxDate {
+                return false
+            }
+        }
+        return true
     }
     
     var isErrorShown: Bool {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -283,10 +283,9 @@ extension ACRDateField: NSPopoverDelegate {
 extension ACRDateField: ACRTextFieldDelegate {
     func acrTextFieldDidSelectClear(_ textField: ACRTextField) {
         selectedDate = nil
-        if isValid {
-            errorDelegate?.inputHandlingViewShouldHideError(self, currentFocussedView: iconImage)
-            textField.hideError()
-        }
+        guard isValid else { return }
+        errorDelegate?.inputHandlingViewShouldHideError(self, currentFocussedView: iconImage)
+        textField.hideError()
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
@@ -137,6 +137,32 @@ class InputDateRendererTest: XCTestCase {
         XCTAssertEqual(inputDateField.textField.accessibilityValue(), "10-Feb-2000")
     }
     
+    func testInvalidDateRejected() {
+        let minVal = "2023-04-05"
+        let maxVal = "2023-04-25"
+        
+        //date less than min date
+        var val = "2023-04-02"
+        inputDate = .make(value: val, max: maxVal, min: minVal)
+        var inputDateField = renderDateInput()
+        
+        XCTAssertFalse(inputDateField.isValid)
+        
+        //date in right range
+        val = "2023-04-10"
+        inputDate = .make(value: val, max: maxVal, min: minVal)
+        inputDateField = renderDateInput()
+        
+        XCTAssertTrue(inputDateField.isValid)
+        
+        //date greater than max range
+        val = "2023-04-30"
+        inputDate = .make(value: val, max: maxVal, min: minVal)
+        inputDateField = renderDateInput()
+        
+        XCTAssertFalse(inputDateField.isValid)
+    }
+    
     func testAccessibilityLabelV1_3() {
         inputDate = .make()
         

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
@@ -76,13 +76,18 @@ class InputDateRendererTest: XCTestCase {
     
     func testClearsText() {
         let val: String = "2000-11-23"
+        let fakeErrorDelegate = FakeErrorMessageHandlerDelegate()
         inputDate = .make(value: val)
 
         let inputDateField = renderDateInput()
+        inputDateField.errorDelegate = fakeErrorDelegate
+        fakeErrorDelegate.isErrorVisible = true
         inputDateField.textField.clearButton.performClick()
+        
         XCTAssertEqual(inputDateField.textField.stringValue, "")
         XCTAssertNil(inputDateField.dateValue)
         XCTAssertTrue(inputDateField.textField.clearButton.isHidden)
+        XCTAssertFalse(fakeErrorDelegate.isErrorVisible)
     }
     
     func testClearButtonHiddenWithPlaceholder() {
@@ -161,6 +166,22 @@ class InputDateRendererTest: XCTestCase {
         inputDateField = renderDateInput()
         
         XCTAssertFalse(inputDateField.isValid)
+    }
+    
+    func testInvalidDateOnClearRemovesError() {
+        let fakeErrorDelegate = FakeErrorMessageHandlerDelegate()
+        
+        inputDate = .make(value: "2023-04-02", min: "2023-04-05")
+        let inputDateField = renderDateInput()
+        inputDateField.errorDelegate = fakeErrorDelegate
+        fakeErrorDelegate.isErrorVisible = true
+        
+        XCTAssertFalse(inputDateField.isValid)
+        
+        inputDateField.textField.clearButton.performClick()
+        
+        XCTAssertTrue(inputDateField.isValid)
+        XCTAssertFalse(fakeErrorDelegate.isErrorVisible)
     }
     
     func testAccessibilityLabelV1_3() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
@@ -76,13 +76,18 @@ class InputTimeRendererTest: XCTestCase {
     
     func testClearsText() {
         let val: String = "16:23:30"
+        let fakeErrorDelegate = FakeErrorMessageHandlerDelegate()
         inputTime = .make(value: val)
 
         let inputTimeField = renderTimeInput()
+        inputTimeField.errorDelegate = fakeErrorDelegate
+        fakeErrorDelegate.isErrorVisible = true
         inputTimeField.textField.clearButton.performClick()
+        
         XCTAssertNil(inputTimeField.dateValue)
         XCTAssertEqual(inputTimeField.textField.stringValue, "")
         XCTAssertTrue(inputTimeField.textField.clearButton.isHidden)
+        XCTAssertFalse(fakeErrorDelegate.isErrorVisible)
     }
     
     func testClearButtonHiddenWithPlaceholder() {
@@ -161,6 +166,22 @@ class InputTimeRendererTest: XCTestCase {
         inputTimeField = renderTimeInput()
         
         XCTAssertFalse(inputTimeField.isValid)
+    }
+    
+    func testInvalidTimeOnClearRemovesError() {
+        let fakeErrorDelegate = FakeErrorMessageHandlerDelegate()
+        
+        inputTime = .make(value: "8:25", min: "10:15")
+        let inputTimeField = renderTimeInput()
+        inputTimeField.errorDelegate = fakeErrorDelegate
+        fakeErrorDelegate.isErrorVisible = true
+        
+        XCTAssertFalse(inputTimeField.isValid)
+        
+        inputTimeField.textField.clearButton.performClick()
+        
+        XCTAssertTrue(inputTimeField.isValid)
+        XCTAssertFalse(fakeErrorDelegate.isErrorVisible)
     }
 
     private func renderTimeInput() -> ACRDateField {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
@@ -136,6 +136,32 @@ class InputTimeRendererTest: XCTestCase {
         XCTAssertEqual(inputTimeField.accessibilityRoleDescription(), "Time Picker")
         XCTAssertEqual(inputTimeField.textField.accessibilityValue(), "12:24 PM")
     }
+    
+    func testInvalidTimeRejected() {
+        let minVal = "10:15"
+        let maxVal = "16:45"
+        
+        //date less than min date
+        var val = "8:25"
+        inputTime = .make(value: val, max: maxVal, min: minVal)
+        var inputTimeField = renderTimeInput()
+        
+        XCTAssertFalse(inputTimeField.isValid)
+        
+        //date in right range
+        val = "12:00"
+        inputTime = .make(value: val, max: maxVal, min: minVal)
+        inputTimeField = renderTimeInput()
+        
+        XCTAssertTrue(inputTimeField.isValid)
+        
+        //date greater than max range
+        val = "20:45"
+        inputTime = .make(value: val, max: maxVal, min: minVal)
+        inputTimeField = renderTimeInput()
+        
+        XCTAssertFalse(inputTimeField.isValid)
+    }
 
     private func renderTimeInput() -> ACRDateField {
         let view = inputTimeRenderer.render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestHelpers.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestHelpers.swift
@@ -54,11 +54,11 @@ class FakeErrorMessageHandlerDelegate: InputHandlingViewErrorDelegate {
     var isErrorVisible: Bool = false
     var isErrorMessageAnnounced: Bool = false
     func inputHandlingViewShouldShowError(_ view: InputHandlingViewProtocol) {
-        isErrorVisible = false
+        isErrorVisible = true
     }
     
     func inputHandlingViewShouldHideError(_ view: InputHandlingViewProtocol, currentFocussedView: NSView?) {
-        isErrorVisible = true
+        isErrorVisible = false
     }
     
     func inputHandlingViewShouldAnnounceErrorMessage(_ view: InputHandlingViewProtocol, message: String?) {


### PR DESCRIPTION


## Description
If the default value provided was beyond the date/time range, user would be able to submit the value, since no checks are done on submit for date/time for min and max. This was resolved here

## Sample Card
https://app.vidcast.io/share/70e4cc16-2408-4d02-93e5-f4c91cb2d8f3

## How Verified
Added tests
