### PR TITLE
macOS: Fixed issue with long placeholder/value in single line text fields

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LongPlaceholderAndValue.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/LongPlaceholderAndValue.json
@@ -1,0 +1,37 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+            {
+            "type": "Input.Text",
+            "id": "text",
+        "value": "Long value present to test if this affects single line text input blah blah blah",
+            "label": "Label",
+            "isRequired": true,
+            "errorMessage": "Error Message"
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text which is very very long to try and cause issue in the cell",
+            "id": "number",
+            "label": "Label",
+            "isRequired": true,
+            "errorMessage": "Error Message"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Action.Submit"
+        },
+        {
+            "type": "Action.ToggleVisibility",
+            "title": "Toggle number",
+            "targetElements": [
+                "number"
+            ]
+        }
+    ]
+}
+

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRFactSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRFactSetView.swift
@@ -3,7 +3,6 @@ import AppKit
 
 // MARK: Class required for Horizontal Stack View
 class ACRFactSetView: NSView {
-    
     init() {
         super.init(frame: .zero)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
@@ -31,7 +31,7 @@ class ACRTextField: NSTextField {
         super.init(frame: .zero)
         initialise()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -42,7 +42,7 @@ class ACRTextField: NSTextField {
         errorMessage = inputElement.getErrorMessage()
         setAccessibilityPlaceholderValue(nil)
     }
-
+    
     private func initialise() {
         let customCell = VerticallyCenteredTextFieldCell()
         customCell.drawsBackground = true
@@ -128,7 +128,7 @@ class ACRTextField: NSTextField {
         textFieldDelegate?.acrTextFieldDidSelectClear(self)
         updateClearButton()
     }
-
+    
     override func textDidChange(_ notification: Notification) {
         super.textDidChange(notification)
         updateLastKnownCursorPosition()
@@ -223,7 +223,7 @@ class ACRTextField: NSTextField {
             accessibilityTitle += accessibilityTitle.isEmpty ? "" : ", "
             accessibilityTitle += placeholder
         }
-    
+        
         return accessibilityTitle
     }
     
@@ -266,14 +266,17 @@ class ACRTextField: NSTextField {
     }
 }
 
- class VerticallyCenteredTextFieldCell: NSTextFieldCell {
+class VerticallyCenteredTextFieldCell: NSTextFieldCell {
+    private struct Constants {
+        static let rightPaddingWithClearButton: CGFloat = 20
+    }
     private var rightPadding: CGFloat = 0
     private var leftPadding: CGFloat = 0
     private var yPadding: CGFloat = 0
     private var focusRingCornerRadius: CGFloat = 0
     private var wantsClearButton = false
     private var isNumericField = false
-
+    
     func setupSpacing(rightPadding: CGFloat = 0, leftPadding: CGFloat = 0, yPadding: CGFloat = 0, focusRingCornerRadius: CGFloat = 0, wantsClearButton: Bool, isNumericField: Bool) {
         self.leftPadding = leftPadding
         self.rightPadding = rightPadding
@@ -282,28 +285,31 @@ class ACRTextField: NSTextField {
         self.wantsClearButton = wantsClearButton
         self.isNumericField = isNumericField
     }
-
-    override func titleRect(forBounds rect: NSRect) -> NSRect {
-        var titleRect = super.titleRect(forBounds: rect)
-
-        let minimumHeight = self.cellSize(forBounds: rect).height
+    
+    private func adjustedFrame(forBounds rect: NSRect) -> NSRect {
+        var newRect = rect
         // Subtract yPadding to remove offset due to to font baseline
-        titleRect.origin.y += (titleRect.height - minimumHeight) / 2 - yPadding
-        titleRect.size.height = minimumHeight
-        titleRect.origin.x += leftPadding
-        // 16px is the image size(clear button)
-        titleRect.size.width -= rightPadding + leftPadding + (wantsClearButton ? 16 : 0)
-        return titleRect
+        let yoffset = floor((rect.height - ceil(font?.boundingRectForFont.size.height ?? 0)) / 2) - yPadding
+        newRect.origin.y += yoffset
+        newRect.origin.x += leftPadding
+        if rect.size.width > 0 {
+            newRect.size.width -= rightPadding + leftPadding + (wantsClearButton ? Constants.rightPaddingWithClearButton : 0)
+        }
+        return newRect
     }
-
+    
+    override func titleRect(forBounds rect: NSRect) -> NSRect {
+        return adjustedFrame(forBounds: rect)
+    }
+    
     override func drawInterior(withFrame cellFrame: NSRect, in controlView: NSView) {
         controlView.layer?.cornerRadius = focusRingCornerRadius
-        super.drawInterior(withFrame: titleRect(forBounds: cellFrame), in: controlView)
+        super.drawInterior(withFrame: adjustedFrame(forBounds: cellFrame), in: controlView)
     }
-
+    
     override func select(withFrame rect: NSRect, in controlView: NSView, editor textObj: NSText, delegate: Any?, start selStart: Int, length selLength: Int) {
         controlView.layer?.cornerRadius = focusRingCornerRadius
-        super.select(withFrame: titleRect(forBounds: rect), in: controlView, editor: textObj, delegate: delegate, start: selStart, length: selLength)
+        super.select(withFrame: adjustedFrame(forBounds: rect), in: controlView, editor: textObj, delegate: delegate, start: selStart, length: selLength)
     }
     
     override func drawFocusRingMask(withFrame cellFrame: NSRect, in controlView: NSView) {
@@ -322,4 +328,4 @@ class ACRTextField: NSTextField {
         }
         path.fill()
     }
- }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -122,7 +122,7 @@ class ACRView: ACRColumnView {
                 for handler in handlers {
                     guard !renderConfig.supportsSchemeV1_3 || handler.isValid else {
                         handler.showError()
-                        if isFirstErrorFieldInView {
+                        if isFirstErrorFieldInView && !handler.isHidden {
                             firstFieldWithError = handler
                             resetKeyboardFocus()
                             isFirstErrorFieldInView = false

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRTextFieldTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRTextFieldTests.swift
@@ -130,6 +130,17 @@ class ACRTextFieldTests: XCTestCase {
         XCTAssertEqual(textField.layer?.borderColor, config.inputFieldConfig.activeBorderColor.cgColor)
         XCTAssertEqual(textField.layer?.backgroundColor, config.inputFieldConfig.backgroundColor.cgColor)
     }
+    
+    func testTextFieldCellBounds() {
+        // textField with default padding
+        textField = ACRTextField(textFieldWith: .default, mode: .text, inputElement: inputElement)
+        XCTAssertEqual(textField.cell?.titleRect(forBounds: NSRect(x: 0, y: 0, width: 100, height: 100)), NSRect(x: 0, y: 42, width: 100, height: 100))
+        
+        //textfield With custom Padding
+        let inputConfig = InputFieldConfig(height: 40, leftPadding: 10, rightPadding: 10, yPadding: 5, focusRingCornerRadius: 0, borderWidth: 0, wantsClearButton: true, clearButtonImage: nil, calendarImage: nil, clockImage: nil, font: .systemFont(ofSize: 12), highlightedColor: .blue, backgroundColor: .black, borderColor: .red, activeBorderColor: .green, placeholderTextColor: .black, multilineFieldInsets: NSEdgeInsets(), errorStateConfig: .default, errorBadgeImage: nil)
+        textField = ACRTextField(textFieldWith: RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: false, hyperlinkColorConfig: .default, inputFieldConfig: inputConfig, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil), mode: .text, inputElement: inputElement)
+        XCTAssertEqual(textField.cell?.titleRect(forBounds: NSRect(x: 0, y: 0, width: 100, height: 100)), NSRect(x: 10, y: 37, width: 60, height: 100)) 
+    }
 }
 
 private class FakeACRTextFieldDelegate: ACRTextFieldDelegate {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -479,6 +479,25 @@ class ACRViewTests: XCTestCase {
         XCTAssertFalse(handler1.isFocused)
         XCTAssertTrue(handler2.isFocused)
     }
+    
+    func testInputHandlerRefocusOnVisibleTextFieldOnError() {
+        let renderConfig = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: .default)
+        let view = ACRView(style: .default, hostConfig: FakeHostConfig.make(), renderConfig: renderConfig)
+        let handler1 = FakeInputHandlingView()
+        let handler2 = FakeInputHandlingView()
+        
+        handler1.isValid = false
+        handler1.isHidden = true
+        handler2.isValid = false
+        
+        view.addInputHandler(handler1)
+        view.addInputHandler(handler2)
+        
+        view.handleSubmitAction(actionView: NSButton(), dataJson: nil, associatedInputs: true)
+        
+        XCTAssertFalse(handler1.isFocused)
+        XCTAssertTrue(handler2.isFocused)
+    }
 }
 
 private class FakeInputHandlingView: NSView, InputHandlingViewProtocol {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -486,6 +486,7 @@ class ACRViewTests: XCTestCase {
         let handler1 = FakeInputHandlingView()
         let handler2 = FakeInputHandlingView()
         
+        // Case 1: First invalid view hidden so focus on second invalid view
         handler1.isValid = false
         handler1.isHidden = true
         handler2.isValid = false
@@ -497,6 +498,20 @@ class ACRViewTests: XCTestCase {
         
         XCTAssertFalse(handler1.isFocused)
         XCTAssertTrue(handler2.isFocused)
+        
+        // Case 2: First invalid view visible so focus on that and not second invalid view
+        handler1.isFocused = false
+        handler1.isValid = false
+        handler1.isHidden = false
+        
+        handler2.isFocused = false
+        handler2.isValid = false
+        handler2.isHidden = false
+        
+        view.handleSubmitAction(actionView: NSButton(), dataJson: nil, associatedInputs: true)
+        
+        XCTAssertTrue(handler1.isFocused)
+        XCTAssertFalse(handler2.isFocused)
     }
 }
 


### PR DESCRIPTION
## Description
Fixed issue where single line text field does not vertically align if the placeholder/value is too long
Fixed ssue where the textfield cell moves to the left if it gets selected when hidden

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
Old:
<img width="435" alt="Screenshot 2023-05-02 at 3 00 19 PM" src="https://user-images.githubusercontent.com/78855675/235666589-9b8c3124-2d78-4e08-be46-870ecb552063.png">
New:
<img width="435" alt="Screenshot 2023-05-02 at 3 00 48 PM" src="https://user-images.githubusercontent.com/78855675/235666638-5a81a78b-a8f8-43a7-9733-6416071cb4c8.png">

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
