### PR TITLE
(mac) Fix Input Number Max size issue

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/InputNumberWithExponents.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/InputNumberWithExponents.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "Input.Number",
+            "id": "num1",
+            "placeholder": "Enter a number",
+            "value": 2,
+            "label": "Normal Number"
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "id": "num2",
+            "label": "Normal exponent value",
+            "value": 5e4
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "id": "num3",
+            "label": "Large exponent value",
+            "value": 3e+250
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "label": "Large Negative value",
+            "id": "num4",
+            "value": -1.872e+275
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "label": "Small exponent value(positive)",
+            "value": 1.2e-300,
+            "id": "num5"
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "label": "Small exponent value(negative)",
+            "value": -1.2e-300,
+            "id": "num6"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "OK"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSNumberInput.mm
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSNumberInput.mm
@@ -45,13 +45,13 @@
 {
  
     auto getValueCpp = mCppObj->GetValue();
-    return getValueCpp.has_value() ? [NSNumber numberWithInt:getValueCpp.value_or(0)] : NULL;
+    return getValueCpp.has_value() ? [NSNumber numberWithDouble:getValueCpp.value_or(0)] : NULL;
 
 }
 
 - (void)setValue:(NSNumber * _Nullable)value
 {
-    auto valueCpp = [value intValue];
+    auto valueCpp = [value doubleValue];
  
     mCppObj->SetValue(valueCpp);
     
@@ -61,13 +61,13 @@
 {
  
     auto getMaxCpp = mCppObj->GetMax();
-    return getMaxCpp.has_value() ? [NSNumber numberWithInt:getMaxCpp.value_or(0)] : NULL;
+    return getMaxCpp.has_value() ? [NSNumber numberWithDouble:getMaxCpp.value_or(0)] : NULL;
 
 }
 
 - (void)setMax:(NSNumber * _Nullable)value
 {
-    auto valueCpp = [value intValue];
+    auto valueCpp = [value doubleValue];
  
     mCppObj->SetMax(valueCpp);
     
@@ -77,13 +77,13 @@
 {
  
     auto getMinCpp = mCppObj->GetMin();
-    return getMinCpp.has_value() ? [NSNumber numberWithInt:getMinCpp.value_or(0)] : NULL;
+    return getMinCpp.has_value() ? [NSNumber numberWithDouble:getMinCpp.value_or(0)] : NULL;
 
 }
 
 - (void)setMin:(NSNumber * _Nullable)value
 {
-    auto valueCpp = [value intValue];
+    auto valueCpp = [value doubleValue];
  
     mCppObj->SetMin(valueCpp);
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
@@ -155,6 +155,20 @@ class InputNumberRendererTest: XCTestCase {
         XCTAssertEqual(inputNumberField.value, "-12.3")
     }
     
+    func testMaxPossibleValue() {
+        inputNumber = .make(max:NSNumber(floatLiteral: Double.greatestFiniteMagnitude + 1))
+        
+        let inputNumberField = renderNumberInput()
+        XCTAssertEqual(inputNumberField.maxValue, Double.greatestFiniteMagnitude)
+    }
+    
+    func testMinPossibleValue() {
+        inputNumber = .make(max:NSNumber(floatLiteral: -(Double.greatestFiniteMagnitude + 1)))
+        
+        let inputNumberField = renderNumberInput()
+        XCTAssertEqual(inputNumberField.maxValue, -Double.greatestFiniteMagnitude)
+    }
+    
     func testAccessibilityValueSet() {
         let val: NSNumber = 20.00
         inputNumber = .make(value: val)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRNumericTextFieldTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRNumericTextFieldTests.swift
@@ -129,6 +129,32 @@ class ACRNumericTestFieldTests: XCTestCase {
         XCTAssertEqual(numericView.value, "-2e-20")
     }
     
+    func testInvalidNumberEntered() {
+        // "-" only allowed at start or after e
+        numericView.textField.stringValue = "-2.50e20-"
+        var object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2.5e+20")
+        
+        // "+" only allowed after e
+        numericView.textField.stringValue = "-2.50e20+"
+        object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2.5e+20")
+        
+        // "Only 1 "." allowed
+        numericView.textField.stringValue = "-2.4."
+        object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2.4")
+        
+        // "Only 1 "e" allowed
+        numericView.textField.stringValue = "-2.4e+100e"
+        object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2.4e+100")
+    }
+    
     func testAccessibilityTitle1_2() {
         numericView.attributedPlaceholder = NSAttributedString(string: "Placeholder")
         XCTAssertNil(numericView.accessibilityTitle())

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRNumericTextFieldTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRNumericTextFieldTests.swift
@@ -101,6 +101,34 @@ class ACRNumericTestFieldTests: XCTestCase {
         XCTAssertTrue(numericView.isValid)
     }
     
+    func testExponentPointEntered() {
+        numericView.textField.stringValue = "2.50e20"
+        let object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "2.5e+20")
+    }
+    
+    func testnegativeExponentPointEntered() {
+        numericView.textField.stringValue = "2.50e-20"
+        let object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "2.5e-20")
+    }
+    
+    func testNegativeNumberExponentPointEntered() {
+        numericView.textField.stringValue = "-2.50e20"
+        let object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2.5e+20")
+    }
+    
+    func testNegativeNumberNegativeExponentPointEntered() {
+        numericView.textField.stringValue = "-2e-20"
+        let object = Notification(name: NSNotification.Name.init("NSControlTextDidChangeNotification"), object: numericView.textField)
+        numericView.controlTextDidChange(object)
+        XCTAssertEqual(numericView.value, "-2e-20")
+    }
+    
     func testAccessibilityTitle1_2() {
         numericView.attributedPlaceholder = NSAttributedString(string: "Placeholder")
         XCTAssertNil(numericView.accessibilityTitle())


### PR DESCRIPTION

## Description

Fixed issue with input number not allowing exponents
Fixed issue to increase max, min and value from int max to double max

## Sample Card
Original : Render fails since default value too large
Updated:
<img width="431" alt="Screenshot 2023-05-16 at 12 17 35 PM" src="https://github.com/webex/AdaptiveCards/assets/78855675/73c0cd40-fc35-4469-adfc-44601932cd96">


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
