### PR TITLE
[mac]Fix crash in updated shared code in choice set

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/EmptyElemtsInArray.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/EmptyElemtsInArray.json
@@ -1,0 +1,43 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.2",
+    "body": [
+        {
+            "type": "Input.ChoiceSet",
+            "id": "test"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "test1",
+            "style": "expanded"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "test2",
+            "isMultiSelect": true
+        },
+        {
+            "type": "RichTextBlock",
+            "inlines": []
+        },
+        {
+            "type": "FactSet"
+        },
+        {
+            "type": "Container"
+        },
+        {
+            "type": "ColumnSet"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch"
+                }
+            ]
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetCompactPopupButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetCompactPopupButton.swift
@@ -66,11 +66,12 @@ class ACRChoiceSetCompactPopupButton: NSPopUpButton, InputHandlingViewProtocol {
     }
     
     func setToolTip() {
+        guard !itemArray.isEmpty else { return }
         toolTip = itemArray[indexOfSelectedItem].title
     }
     
     var value: String {
-        return arrayValues[indexOfSelectedItem] ?? ""
+        return arrayValues.isEmpty ? "" : arrayValues[indexOfSelectedItem] ?? ""
     }
     
     var key: String {
@@ -87,7 +88,7 @@ class ACRChoiceSetCompactPopupButton: NSPopUpButton, InputHandlingViewProtocol {
     
     override func accessibilityValue() -> Any? {
         guard renderConfig.supportsSchemeV1_3 else {
-            return itemArray[indexOfSelectedItem].title
+            return itemArray.isEmpty ? "" : itemArray[indexOfSelectedItem].title
         }
         var accessibilityLabel = ""
         if let errorDelegate = errorDelegate, errorDelegate.isErrorVisible(self) {
@@ -97,13 +98,13 @@ class ACRChoiceSetCompactPopupButton: NSPopUpButton, InputHandlingViewProtocol {
             }
         }
         if let label = label, !label.isEmpty {
-            accessibilityLabel += label + ", "
+            accessibilityLabel += label
         }
-        accessibilityLabel += itemArray[indexOfSelectedItem].title
+        accessibilityLabel += itemArray.isEmpty ? "" : (", " + itemArray[indexOfSelectedItem].title)
         return accessibilityLabel
     }
     
     var isValid: Bool {
-        return isRequired ? (arrayValues[indexOfSelectedItem] != nil) : true
+        return isRequired ? (arrayValues.isEmpty ? false : (arrayValues[indexOfSelectedItem] != nil)) : true
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
@@ -179,6 +179,49 @@ class ChoiceSetInputRendererTests: XCTestCase {
         XCTAssertEqual(choiceSetCompactView.choiceSetPopup.itemArray[1].toolTip, "Test Title 2")
     }
     
+    func testCompactChoiceSetTooltipWhenEpty() {
+        button = .make(title: "", value: "")
+        choices.removeAll()
+        choices.append(button)
+        choiceSetInput = .make(choices: choices, choiceSetStyle: .compact, heightType: .auto)
+        
+        let choiceSetCompactView = renderChoiceSetCompactView()
+        
+        XCTAssertEqual(choiceSetCompactView.choiceSetPopup.toolTip, "")
+    }
+    
+    func testChoiceSetAccessibilityValue() {
+        button = .make(title: "Test Title", value: "Test Value")
+        choices.removeAll()
+        choices.append(button)
+        choiceSetInput = .make(choices: choices, choiceSetStyle: .compact, heightType: .auto)
+        
+        let choiceSetCompactView = renderChoiceSetCompactView()
+        
+        XCTAssertEqual(choiceSetCompactView.accessibilityValue() as? String, "Test Title")
+    }
+    
+    func testChoiceSetAccessibilityValueWhenEpmty() {
+        button = .make(title: "", value: "")
+        choices.removeAll()
+        choices.append(button)
+        choiceSetInput = .make(choices: choices, choiceSetStyle: .compact, heightType: .auto)
+        
+        let choiceSetCompactView = renderChoiceSetCompactView()
+        
+        XCTAssertEqual(choiceSetCompactView.accessibilityValue() as? String, "")
+    }
+    
+    func testisInValidSetForChoiceSetWhenEmpty(){
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        choices.removeAll()
+        choiceSetInput = .make(value: "", choices: choices, choiceSetStyle: .compact, placeholder: "Test", isRequired: true)
+        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRCompactChoiceSetView)
+        guard let choiceSetView = view as? ACRCompactChoiceSetView else { fatalError() }
+        XCTAssertFalse(choiceSetView.choiceSetPopup.isValid)
+    }
+    
     private func renderChoiceSetView() -> ACRChoiceSetView {
         let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         


### PR DESCRIPTION


## Description
Fix crash when new choice set is added but has no items, earlier json parsing would crash, now parsing passes, so we need to handle indexOutOfBounds

## Sample Card
<img width="561" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/95362321-80a1-42de-9246-eab73349f093">


## How Verified
* Added tests
* Checked all elements which have possibility of empty arrays
