### PR TITLE
[macOS] Focus Accessibility: Implement for action ShowCard & Toggle

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -290,7 +290,6 @@ extension RootViewController: AdaptiveCardActionDelegate {
     
     func adaptiveCard(_ adaptiveCard: NSView, didShowCardWith actionView: NSView, previousHeight: CGFloat, newHeight: CGFloat) {
         print("SHOW CARD ACTION: Height changed from \(previousHeight) to \(newHeight)")
-        AdaptiveCard.calculateKeyViewLoop(for: adaptiveCard)
     }
 }
 


### PR DESCRIPTION
# Related Issue/Fix/Implement

- Implement logic for handle show card element order with insert pointer head
- Implement logic for handle skip the hidden view and assign immediate next view
- optimise recalculateKeyViewLoop logic
- Implement refocus logic for action.Toggle and show card
- add unit test

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

![Jun-14-2023 19-20-36](https://github.com/webex/AdaptiveCards/assets/105660080/68cca044-6506-4947-a885-04522994941f)
![Jun-14-2023 19-22-34](https://github.com/webex/AdaptiveCards/assets/105660080/0f0c023a-2dd4-4f49-bff9-9b52a72c7d46)
![Jun-14-2023 19-27-06](https://github.com/webex/AdaptiveCards/assets/105660080/fc07985f-0e1c-42cb-8e3f-e53617ada071)

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
