### PR TITLE
[macOS][BnC] Fix: Double Focus Ring around ACRButton

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
@@ -199,6 +199,13 @@ open class FlatButton: NSButton, CALayerDelegate {
         return NSSize(width: totalWidth, height: totalHeight)
     }
     
+    override public func drawFocusRingMask() {
+        let path = NSBezierPath()
+        path.appendRoundedRect(bounds, xRadius: cornerRadius, yRadius: cornerRadius)
+        path.fill()
+        self.needsDisplay = true
+    }
+    
     private func initialize() {
         wantsLayer = true
         layer?.masksToBounds = false


### PR DESCRIPTION


# Related Issue
- add focus ring

A Pull Request should close a **single** issue; multiple issues can be closed when the issues are **small and related**, but that should be an exception not the rule. Please keep Pull Requests small and targeted; large 'code drops' with dozens of files will be closed and asked to split into reviewable pieces. Reviews that need to be large due to dependencies will be
reviewed on a case-by-case basis.

Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issue fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one to aid
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

Original             	   |  Updated
:-------------------------:|:-------------------------:
<img width="140" alt="Screenshot 2023-06-16 at 11 18 03 AM" src="https://github.com/webex/AdaptiveCards/assets/105660080/e07d7de9-a6a3-411e-b26c-ed9020949468">| <img width="139" alt="Screenshot 2023-06-16 at 11 18 32 AM" src="https://github.com/webex/AdaptiveCards/assets/105660080/643fc89d-9aca-46f1-9f0b-ac131d63ec10">

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
