### PR TITLE
[mac] Add Vertical content alignment support with inheritance

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/VerticalContentAlignment1.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/VerticalContentAlignment1.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.3",
+    "minHeight": "150px",
+    "verticalContentAlignment": "Center",
+    "body": [
+        {
+            "type": "Container",
+            "height": "stretch",
+            "backgroundImage": {
+                "url": "https://adaptivecards.io/content/AlkiBeach.jpg"
+            },
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "I am header.",
+                    "height": "stretch"
+                },
+                {
+                    "type": "Container",
+                    "backgroundImage": {
+                        "url": "https://picsum.photos/200/300"
+                    },
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "And I'm like a centered!"
+                        }
+                    ],
+                    "minHeight": "100px"
+                }
+            ],
+            "minHeight": "200px"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "And I'm footer"
+                }
+            ],
+            "minHeight": "100px",
+            "horizontalAlignment": "Left",
+            "verticalContentAlignment": "Bottom"
+        }
+    ]
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/VerticalContentAlignment2.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/VerticalContentAlignment2.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.2",
+    "body": [
+        {
+            "type": "Container",
+            "height": "stretch",
+            "verticalContentAlignment": "bottom",
+            "backgroundImage": {
+                "url": "https://adaptivecards.io/content/AlkiBeach.jpg"
+            },
+            "items": [
+        {
+            "type": "Container",
+            "style":"good",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container 2"
+                }
+            ],
+            "minHeight": "100px"
+        }       ],
+            "minHeight": "200px"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Managers/ACSFillerSpaceManager.swift
@@ -110,6 +110,23 @@ class ACSFillerSpaceManager {
         }
     }
     
+    /// This function reports if a padding view is already hidden or has been marked to be hidden
+    func isPaddingInvisble(invisibleViews: NSMutableSet) -> Bool {
+        if !stretchableViews.isEmpty {
+            for nsValue in stretchableViews {
+                if let view = nsValue.nonretainedObjectValue as? NSView {
+                    if !view.isHidden && !invisibleViews.contains(view) {
+                        return false
+                    }
+                }
+            }
+        }
+        if !(self.lastStretchableView?.isHidden ?? true) {
+            return false
+        }
+        return true
+    }
+    
     /// activates the constraints together for performance
     /// two stretchable views get same height
     /// by setting low priority, the relationship can be overridden

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -51,6 +51,12 @@ class AdaptiveCardRenderer {
         if card.getVersion() == "1.3", !config.supportsSchemeV1_3 {
             logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
         }
+        // Note: This currently does not have any affect since shared code does not allow optional value for card's verticalContentAlignment
+        if card.getVerticalContentAlignment() == .nil, let parentView = parentRootView {
+            rootView.setVerticalContentAlignment(parentView.verticalContentAlignment)
+        } else {
+            rootView.setVerticalContentAlignment(card.getVerticalContentAlignment())
+        }
         for (index, element) in card.getBody().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
@@ -81,7 +87,7 @@ class AdaptiveCardRenderer {
             rootView.registerImageHandlingView(rootView.backgroundImageView, for: url)
         }
         
-        rootView.configureLayoutAndVisibility(verticalContentAlignment: card.getVerticalContentAlignment(), minHeight: card.getMinHeight())
+        rootView.configureLayoutAndVisibility(minHeight: card.getMinHeight())
         rootView.appearance = NSAppearance.getAppearance(isDark: config.isDarkMode)
         rootView.dispatchImageResolveRequests()
         return rootView

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -17,7 +17,12 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         }
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
         columnView.bleed = column.getBleed()
-        
+        if column.getVerticalContentAlignment() == .nil, let parentView = parentView as? ACRContentStackView {
+            columnView.setVerticalContentAlignment(parentView.verticalContentAlignment)
+        } else {
+            columnView.setVerticalContentAlignment(column.getVerticalContentAlignment())
+        }
+		
         for (index, element) in column.getItems().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
@@ -27,7 +32,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: columnView, with: hostConfig, element: element, parentElement: column)
         }
         
-        columnView.configureLayoutAndVisibility(verticalContentAlignment: column.getVerticalContentAlignment(), minHeight: column.getMinHeight())
+        columnView.configureLayoutAndVisibility(minHeight: column.getMinHeight())
         
         if let backgroundImage = column.getBackgroundImage(), let url = backgroundImage.getUrl() {
             columnView.setupBackgroundImageProperties(backgroundImage)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -20,6 +20,12 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             rootView.accessibilityContext?.registerView(columnSetView)
         }
         columnSetView.orientation = .horizontal
+        if columnSet.getVerticalContentAlignment() == .nil, let parentView = parentView as? ACRContentStackView {
+            columnSetView.setVerticalContentAlignment(parentView.verticalContentAlignment)
+        } else {
+            columnSetView.setVerticalContentAlignment(columnSet.getVerticalContentAlignment())
+        }
+        
         var numberOfAutoItems = 0
         var numberOfStretchItems = 0
         var numberOfWeightedItems = 0
@@ -100,7 +106,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
                 }
             }
         }
-        columnSetView.configureLayoutAndVisibility(verticalContentAlignment: columnSet.getVerticalContentAlignment(), minHeight: columnSet.getMinHeight())
+        columnSetView.configureLayoutAndVisibility(minHeight: columnSet.getMinHeight())
         return columnSetView
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -20,6 +20,11 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
         // add selectAction
         containerView.setupSelectAction(container.getSelectAction(), rootView: rootView)
         containerView.setupSelectActionAccessibility(on: containerView, for: container.getSelectAction())
+        if container.getVerticalContentAlignment() == .nil, let parentView = parentView as? ACRContentStackView {
+            containerView.setVerticalContentAlignment(parentView.verticalContentAlignment)
+        } else {
+            containerView.setVerticalContentAlignment(container.getVerticalContentAlignment())
+        }
         
         for (index, element) in container.getItems().enumerated() {
             let isFirstElement = index == 0
@@ -28,7 +33,9 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             BaseCardElementRenderer.shared.updateLayoutForSeparatorAndAlignment(view: view, element: element, parentView: containerView, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: element, parentElement: container)
         }
-        containerView.configureLayoutAndVisibility(verticalContentAlignment: container.getVerticalContentAlignment(), minHeight: container.getMinHeight())
+
+        containerView.configureLayoutAndVisibility(minHeight: container.getMinHeight())
+        
         if container.getHeight() == .stretch {
             containerView.setStretchableHeight()
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -80,7 +80,7 @@ class ACRColumnSetView: ACRContentStackView {
         }
     }
     
-    override func configureLayoutAndVisibility(verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?) {
+    override func configureLayoutAndVisibility(minHeight: NSNumber?) {
         self.applyVisibilityToSubviews()
         self.setMinimumHeight(minHeight)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -119,8 +119,8 @@ class ACRColumnView: ACRContentStackView {
         backgroundImageViewBottomConstraint.isActive = true
     }
     
-    override func configureLayoutAndVisibility(verticalContentAlignment: ACSVerticalContentAlignment, minHeight: NSNumber?) {
-        super.configureLayoutAndVisibility(verticalContentAlignment: verticalContentAlignment, minHeight: minHeight)
+    override func configureLayoutAndVisibility(minHeight: NSNumber?) {
+        super.configureLayoutAndVisibility(minHeight: minHeight)
         setStretchableHeight()
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -4,18 +4,16 @@ import XCTest
 
 class ColumnRendererTests: XCTestCase {
     private var hostConfig: FakeHostConfig!
-    private var column: FakeColumn!
     private var columnRenderer: ColumnRenderer!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
         hostConfig = .make()
-        column = .make()
         columnRenderer = ColumnRenderer()
     }
     
     func testAutoWidth() {
-        column = .make(width: "auto")
+        let column = FakeColumn.make(width: "auto")
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .auto)
         XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.auto.huggingPriority)
@@ -23,7 +21,7 @@ class ColumnRendererTests: XCTestCase {
     }
     
     func testStretchWidth() {
-        column = .make(width: "stretch")
+        let column = FakeColumn.make(width: "stretch")
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .stretch)
         XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.stretch.huggingPriority)
@@ -31,27 +29,27 @@ class ColumnRendererTests: XCTestCase {
     }
     
     func testWeightedWidth() {
-        column = .make(width: "20")
+        let column = FakeColumn.make(width: "20")
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .weighted(20))
     }
     
     func testConstantWidth() {
-        column = .make(width: "0", pixelWidth: 200)
+        let column = FakeColumn.make(width: "0", pixelWidth: 200)
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .fixed(200))
         XCTAssertEqual(columnView.fittingSize.width, 200)
     }
     
     func testMinHeight() {
-        column = .make(minHeight: 200)
+        let column = FakeColumn.make(minHeight: 200)
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.fittingSize.height, 200)
     }
     
     func testVerticalContentAlignment() {
         // since we removed padding view all together and replaced with lastPadding but use paddingView for vertical content alignment this has changed
-        column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .center)
+        var column = FakeColumn.make(items: [FakeTextBlock.make()], verticalContentAlignment: .center)
         var columnView = renderColumnView(column)
         XCTAssertEqual(columnView.arrangedSubviews.count, 4)
         
@@ -68,7 +66,7 @@ class ColumnRendererTests: XCTestCase {
     func testSelectActionTargetIsSet() {
         var columnView: ACRColumnView!
         
-        column = .make(selectAction: FakeSubmitAction.make())
+        var column = FakeColumn.make(selectAction: FakeSubmitAction.make())
         columnView = renderColumnView(column)
         
         XCTAssertNotNil(columnView.target)
@@ -102,39 +100,39 @@ class ColumnRendererTests: XCTestCase {
     }
     
     func testRendersItems() {
-        column = .make(items: [FakeTextBlock.make(), FakeInputNumber.make()])
+        let column = FakeColumn.make(items: [FakeTextBlock.make(), FakeInputNumber.make()])
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.arrangedSubviews.count, 4)
     }
     
     func testDateFieldWidth() {
-        column = .make(items: [FakeInputDate.make()])
+        let column = FakeColumn.make(items: [FakeInputDate.make()])
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.minWidthConstraint.constant, 100)
     }
     
     func testIntrinsicContentSizeWithHiddenInputElements() {
         let inputField = FakeInputText.make(id: "id", isRequired: true, errorMessage: "error message", label: "label message", separator: false, heightType: .auto, isVisible: false)
-        column = FakeColumn.make(isVisible: true, items: [inputField])
+        let column = FakeColumn.make(isVisible: true, items: [inputField])
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.intrinsicContentSize, .zero)
     }
     
     func testPaddingWhenContainerEmptyWithoutStyle() {
         // No padding added
-        column = FakeColumn.make(isVisible: true, style: .none)
+        let column = FakeColumn.make(isVisible: true, style: .none)
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.stackView.arrangedSubviews.count, 1)
     }
     
     func testColumnWithHeight() {
-        column = FakeColumn.make(isVisible: true, style: .accent, height: .stretch)
+        let column = FakeColumn.make(isVisible: true, style: .accent, height: .stretch)
         let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.stackView.arrangedSubviews.count, 1)
     }
     
     func testEmptyColumnRendersWithoutError() {
-        column = .make(items: [])
+        let column = FakeColumn.make(items: [])
         
         XCTAssertNoThrow(renderColumnView(column))
     }
@@ -142,7 +140,7 @@ class ColumnRendererTests: XCTestCase {
     func testRendererInheritsVerticalContentAlignment() {
         var parentColumn = FakeColumn.make(verticalContentAlignment: .top)
         var parentColumnView = renderColumnView(parentColumn)
-        column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .nil)
+        let column = FakeColumn.make(items: [FakeTextBlock.make()], verticalContentAlignment: .nil)
         var columnView = renderColumnView(column, parentView: parentColumnView)
         
         // For HeightType Property we have add stretchable view. so it will increase count for subviews.
@@ -165,7 +163,7 @@ class ColumnRendererTests: XCTestCase {
     
     func testInvisibleViewsWithVerticalContentAlignment() {
         let stretcableView = FakeColumn.make(height: .stretch)
-        column = .make(items: [stretcableView], verticalContentAlignment: .bottom)
+        let column = FakeColumn.make(items: [stretcableView], verticalContentAlignment: .bottom)
         let columnView = renderColumnView(column)
         
         // Normally there are 3 subviews in case of botom, with stretcable view, it is reduced to 2

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -16,7 +16,7 @@ class ColumnRendererTests: XCTestCase {
     
     func testAutoWidth() {
         column = .make(width: "auto")
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .auto)
         XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.auto.huggingPriority)
         XCTAssertEqual(columnView.contentCompressionResistancePriority(for: .horizontal), .defaultHigh)
@@ -24,7 +24,7 @@ class ColumnRendererTests: XCTestCase {
     
     func testStretchWidth() {
         column = .make(width: "stretch")
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .stretch)
         XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.stretch.huggingPriority)
         XCTAssertEqual(columnView.contentCompressionResistancePriority(for: .horizontal), .defaultLow)
@@ -32,35 +32,35 @@ class ColumnRendererTests: XCTestCase {
     
     func testWeightedWidth() {
         column = .make(width: "20")
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .weighted(20))
     }
     
     func testConstantWidth() {
         column = .make(width: "0", pixelWidth: 200)
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.columnWidth, .fixed(200))
         XCTAssertEqual(columnView.fittingSize.width, 200)
     }
     
     func testMinHeight() {
         column = .make(minHeight: 200)
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.fittingSize.height, 200)
     }
     
     func testVerticalContentAlignment() {
         // since we removed padding view all together and replaced with lastPadding but use paddingView for vertical content alignment this has changed
         column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .center)
-        var columnView = renderColumnView()
+        var columnView = renderColumnView(column)
         XCTAssertEqual(columnView.arrangedSubviews.count, 4)
         
         column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .bottom)
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
         XCTAssertEqual(columnView.arrangedSubviews.count, 3)
         
         column = .make(items: [FakeTextBlock.make(heightType: .stretch)], verticalContentAlignment: .center)
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
         XCTAssertTrue(columnView.arrangedSubviews.last?.isHidden ?? false)
         XCTAssertEqual(columnView.arrangedSubviews.count, 2)
     }
@@ -69,7 +69,7 @@ class ColumnRendererTests: XCTestCase {
         var columnView: ACRColumnView!
         
         column = .make(selectAction: FakeSubmitAction.make())
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
         
         XCTAssertNotNil(columnView.target)
         XCTAssertTrue(columnView.target is ActionSubmitTarget)
@@ -77,7 +77,7 @@ class ColumnRendererTests: XCTestCase {
         XCTAssertTrue(columnView.acceptsFirstResponder)
         
         column = .make(selectAction: FakeOpenURLAction.make())
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
         
         XCTAssertNotNil(columnView.target)
         XCTAssertTrue(columnView.target is ActionOpenURLTarget)
@@ -85,7 +85,7 @@ class ColumnRendererTests: XCTestCase {
         XCTAssertTrue(columnView.acceptsFirstResponder)
         
         column = .make(selectAction: FakeToggleVisibilityAction.make())
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
         
         XCTAssertNotNil(columnView.target)
         XCTAssertTrue(columnView.target is ActionToggleVisibilityTarget)
@@ -94,7 +94,7 @@ class ColumnRendererTests: XCTestCase {
         
         // ShowCard Action is not available as a SelectAction
         column = .make(selectAction: FakeShowCardAction.make())
-        columnView = renderColumnView()
+        columnView = renderColumnView(column)
     
         XCTAssertNil(columnView.target)
         XCTAssertFalse(columnView.canBecomeKeyView)
@@ -103,44 +103,77 @@ class ColumnRendererTests: XCTestCase {
     
     func testRendersItems() {
         column = .make(items: [FakeTextBlock.make(), FakeInputNumber.make()])
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.arrangedSubviews.count, 4)
     }
     
     func testDateFieldWidth() {
         column = .make(items: [FakeInputDate.make()])
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.minWidthConstraint.constant, 100)
     }
     
     func testIntrinsicContentSizeWithHiddenInputElements() {
         let inputField = FakeInputText.make(id: "id", isRequired: true, errorMessage: "error message", label: "label message", separator: false, heightType: .auto, isVisible: false)
         column = FakeColumn.make(isVisible: true, items: [inputField])
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.intrinsicContentSize, .zero)
     }
     
     func testPaddingWhenContainerEmptyWithoutStyle() {
         // No padding added
         column = FakeColumn.make(isVisible: true, style: .none)
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.stackView.arrangedSubviews.count, 1)
     }
     
     func testColumnWithHeight() {
         column = FakeColumn.make(isVisible: true, style: .accent, height: .stretch)
-        let columnView = renderColumnView()
+        let columnView = renderColumnView(column)
         XCTAssertEqual(columnView.stackView.arrangedSubviews.count, 1)
     }
     
     func testEmptyColumnRendersWithoutError() {
         column = .make(items: [])
         
-        XCTAssertNoThrow(renderColumnView())
+        XCTAssertNoThrow(renderColumnView(column))
     }
     
-    private func renderColumnView() -> ACRColumnView {
-        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
+    func testRendererInheritsVerticalContentAlignment() {
+        var parentColumn = FakeColumn.make(verticalContentAlignment: .top)
+        var parentColumnView = renderColumnView(parentColumn)
+        column = .make(items: [FakeTextBlock.make()], verticalContentAlignment: .nil)
+        var columnView = renderColumnView(column, parentView: parentColumnView)
+        
+        // For HeightType Property we have add stretchable view. so it will increase count for subviews.
+        XCTAssertEqual(columnView.stackView.arrangedSubviews.capacity, 2)
+        
+        parentColumn = FakeColumn.make(verticalContentAlignment: .center)
+        parentColumnView = renderColumnView(parentColumn)
+        columnView = renderColumnView(column, parentView: parentColumnView)
+        
+        // SpaceView 2
+        XCTAssertEqual(columnView.stackView.arrangedSubviews.capacity, 4)
+        
+        parentColumn = FakeColumn.make(verticalContentAlignment: .bottom)
+        parentColumnView = renderColumnView(parentColumn)
+        columnView = renderColumnView(column, parentView: parentColumnView)
+        // since we removed padding view all together and replaced with lastPadding but use paddingView for vertical content alignment this has changed
+        // SpaceView 1
+        XCTAssertEqual(columnView.stackView.arrangedSubviews.capacity, 3)
+    }
+    
+    func testInvisibleViewsWithVerticalContentAlignment() {
+        let stretcableView = FakeColumn.make(height: .stretch)
+        column = .make(items: [stretcableView], verticalContentAlignment: .bottom)
+        let columnView = renderColumnView(column)
+        
+        // Normally there are 3 subviews in case of botom, with stretcable view, it is reduced to 2
+        XCTAssertEqual(columnView.stackView.arrangedSubviews.capacity, 2)
+    }
+    
+    private func renderColumnView(_ element: ACSColumn, parentView: NSView = NSView()) -> ACRColumnView {
+        let view = columnRenderer.render(element: element, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: parentView, inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnView = view as? ACRColumnView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -4,18 +4,16 @@ import XCTest
 
 class ContainerRendererTests: XCTestCase {
     private var hostConfig: FakeHostConfig!
-    private var container: FakeContainer!
     private var containerRenderer: ContainerRenderer!
    
     override func setUpWithError() throws {
         try super.setUpWithError()
         hostConfig = .make()
-        container = .make()
         containerRenderer = ContainerRenderer()
     }
     
     func testRendererSetsStyle() {
-        container = .make(style: .none)
+        let container = FakeContainer.make(style: .none)
         let containerView = renderContainerView(container)
         XCTAssertEqual(containerView.layer?.backgroundColor, nil)
     }
@@ -40,7 +38,7 @@ class ContainerRendererTests: XCTestCase {
     }
     
     func testRendererSetsVerticalContentAlignment() {
-        container = .make(verticalContentAlignment: .top, items: [FakeTextBlock.make()])
+        var container = FakeContainer.make(verticalContentAlignment: .top, items: [FakeTextBlock.make()])
         // Removing this since we don't need subviews to have padding to have explicit width
         var containerView = renderContainerView(container)
         // For HeightType Property we have add stretchable view. so it will increase count for subviews.
@@ -66,7 +64,7 @@ class ContainerRendererTests: XCTestCase {
     func testRendererInheritsVerticalContentAlignment() {
         var parentContainer = FakeContainer.make(verticalContentAlignment: .top)
         var parentContainerView = renderContainerView(parentContainer)
-        container = .make(verticalContentAlignment: .nil, items: [FakeTextBlock.make()])
+        let container = FakeContainer.make(verticalContentAlignment: .nil, items: [FakeTextBlock.make()])
         var containerView = renderContainerView(container, parentView: parentContainerView)
         
         // For HeightType Property we have add stretchable view. so it will increase count for subviews.
@@ -89,7 +87,7 @@ class ContainerRendererTests: XCTestCase {
     
     func testInvisibleViewsWithVerticalContentAlignment() {
         let stretcableView = FakeContainer.make(heightType: .stretch)
-        container = .make(verticalContentAlignment: .bottom, items: [stretcableView])
+        let container = FakeContainer.make(verticalContentAlignment: .bottom, items: [stretcableView])
         let containerView = renderContainerView(container)
         
         // Normally there are 3 subviews in case of botom, with stretcable view, it is reduced to 2
@@ -99,7 +97,7 @@ class ContainerRendererTests: XCTestCase {
     func testSelectActionTargetIsSet() {
         var containerView: ACRContentStackView!
         
-        container = .make(selectAction: FakeSubmitAction.make())
+        var container = FakeContainer.make(selectAction: FakeSubmitAction.make())
         containerView = renderContainerView(container)
         
         XCTAssertNotNil(containerView.target)
@@ -144,13 +142,13 @@ class ContainerRendererTests: XCTestCase {
     }
     
     func testRendersItems() {
-        container = .make(items: [FakeInputToggle.make()])
+        let container = FakeContainer.make(items: [FakeInputToggle.make()])
         let containerView = renderContainerView(container)
         XCTAssertEqual(containerView.arrangedSubviews.count, 2)
     }
     
     func testRendersWhenNoItems() {
-        container = .make(items: [])
+        let container = FakeContainer.make(items: [])
         XCTAssertNoThrow(renderContainerView(container))
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -63,6 +63,39 @@ class ContainerRendererTests: XCTestCase {
         XCTAssertEqual(containerView.arrangedSubviews.count, 2)
     }
     
+    func testRendererInheritsVerticalContentAlignment() {
+        var parentContainer = FakeContainer.make(verticalContentAlignment: .top)
+        var parentContainerView = renderContainerView(parentContainer)
+        container = .make(verticalContentAlignment: .nil, items: [FakeTextBlock.make()])
+        var containerView = renderContainerView(container, parentView: parentContainerView)
+        
+        // For HeightType Property we have add stretchable view. so it will increase count for subviews.
+        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 2)
+        
+        parentContainer = FakeContainer.make(verticalContentAlignment: .center)
+        parentContainerView = renderContainerView(parentContainer)
+        containerView = renderContainerView(container, parentView: parentContainerView)
+        
+        // SpaceView 2
+        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 4)
+        
+        parentContainer = FakeContainer.make(verticalContentAlignment: .bottom)
+        parentContainerView = renderContainerView(parentContainer)
+        containerView = renderContainerView(container, parentView: parentContainerView)
+        // since we removed padding view all together and replaced with lastPadding but use paddingView for vertical content alignment this has changed
+        // SpaceView 1
+        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 3)
+    }
+    
+    func testInvisibleViewsWithVerticalContentAlignment() {
+        let stretcableView = FakeContainer.make(heightType: .stretch)
+        container = .make(verticalContentAlignment: .bottom, items: [stretcableView])
+        let containerView = renderContainerView(container)
+        
+        // Normally there are 3 subviews in case of botom, with stretcable view, it is reduced to 2
+        XCTAssertEqual(containerView.stackView.arrangedSubviews.capacity, 2)
+    }
+    
     func testSelectActionTargetIsSet() {
         var containerView: ACRContentStackView!
         
@@ -121,8 +154,8 @@ class ContainerRendererTests: XCTestCase {
         XCTAssertNoThrow(renderContainerView(container))
     }
     
-    private func renderContainerView(_ element: ACSContainer) -> ACRContainerView {
-        let view = containerRenderer.render(element: element, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
+    private func renderContainerView(_ element: ACSContainer, parentView: NSView = NSView()) -> ACRContainerView {
+        let view = containerRenderer.render(element: element, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: parentView, inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContainerView)
         guard let containerView = view as? ACRContainerView else { fatalError() }


### PR DESCRIPTION


# Description

Added support for vertical content alignment

# Sample Card

Old:
<img width="493" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/890677ce-b964-4ef1-90dd-8d146968c982">
<img width="491" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/761a567c-e2c1-4549-b2b1-da87a0d8be1a">

New:
<img width="467" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/b75e5a68-70af-4535-8056-3996003f38f3">
<img width="493" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/5e5c07e6-e891-48b3-8e02-db3b80992d4d">


# How Verified

New tests Added
