### PR TITLE
Fix: [macOS] escape from card when we have focus on any TextView

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
@@ -127,9 +127,9 @@ class ACRTextView: NSTextView, SelectActionHandlingProtocol {
     }
     
     override func keyDown(with event: NSEvent) {
-        if !isEditable {
-            switch Int(event.keyCode) {
-            case kVK_Return, kVK_Space:
+        switch Int(event.keyCode) {
+        case kVK_Return, kVK_Space:
+            if !isEditable {
                 let selectedRange = self.selectedRange()
                 if let data = linkDataList.first(where: { data in
                     return selectedRange == data.linkRange
@@ -140,7 +140,9 @@ class ACRTextView: NSTextView, SelectActionHandlingProtocol {
                         action.handleSelectionAction(for: self)
                     }
                 }
-            case kVK_Tab:
+            }
+        case kVK_Tab:
+            if !isEditable {
                 if event.modifierFlags.contains(.shift) {
                     if keyTabEntry, let data = getPreviousTextViewHyperLinkDataClosestToSelectedRange() {
                         self.setSelectedRange(data.linkRange)
@@ -153,9 +155,11 @@ class ACRTextView: NSTextView, SelectActionHandlingProtocol {
                         return
                     }
                 }
-            default:
-                break
             }
+        case kVK_Escape:
+            self.window?.makeFirstResponder(nil)
+        default:
+            break
         }
         super.keyDown(with: event)
     }


### PR DESCRIPTION
# Related Issue
- Change in ACRTextView key down event


**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
