### PR TITLE
macOS: Fix issue With column auto width

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/MultipleElemetsInColumSet.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/MultipleElemetsInColumSet.json
@@ -1,0 +1,426 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "texte"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text4e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text5e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text45e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text345e"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Date",
+                            "id": "datee"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text4"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text5"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text6"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text7"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "texta"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2a"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3a"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text4a"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text5a"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text45a"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "textb"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2b"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3b"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text4b"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text5b"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "textc"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2c"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3c"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text4c"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "textd"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2d"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text3d"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "textf"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2f"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -48,6 +48,7 @@ class AdaptiveCardRenderer {
         rootView.delegate = actionDelegate
         rootView.resolverDelegate = resourceResolver
         rootView.setMinimumHeight(card.getMinHeight())
+        rootView.setCardWidth(width)
         if card.getVersion() == "1.3", !config.supportsSchemeV1_3 {
             logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -17,6 +17,9 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         }
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
         columnView.bleed = column.getBleed()
+        if let parentView = parentView as? ACRColumnSetView {
+            columnView.setNumberOfColumns(parentView.numberOfColumns)
+        }
         if column.getVerticalContentAlignment() == .nil, let parentView = parentView as? ACRContentStackView {
             columnView.setVerticalContentAlignment(parentView.verticalContentAlignment)
         } else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -6,7 +6,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
     
     struct Constants {
         static let kFillColumnViewVerticalLayoutConstraintPriority = NSLayoutConstraint.Priority.defaultLow - 1
-        static let maxCardWidth: Float = 350.0
+        static let maxCardWidth: CGFloat = 432.0
     }
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
@@ -32,6 +32,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         let totalColumns = columnSet.getColumns().count
         var totalPaddingSpace = Float.zero
         var columnViews: [NSView] = []
+        columnSetView.numberOfColumns = columnSet.getColumns().count
         
         for (index, column) in columnSet.getColumns().enumerated() {
             let isfirstElement = index == 0
@@ -59,13 +60,15 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             }
             columnSetView.distribution = .fill
         } else if numberOfAutoItems == totalColumns {
-            let width = (Constants.maxCardWidth - totalPaddingSpace) / Float(columnViews.count)
-            for index in (0 ..< columnViews.count) {
+            columnSetView.distribution = .gravityAreas
+            // We need to do this as an edge case where there are too many columns so at least no views get hidden
+            let cardWidth = Float(rootView.cardWidth ?? Constants.maxCardWidth)
+            let width = (Float(cardWidth) - totalPaddingSpace) / Float(columnViews.count)
+            for index in (0 ..< columnViews.count) where totalColumns > 5 {
                 let widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
                 widthAnchor.priority = .defaultHigh
                 widthAnchor.isActive = true
             }
-            columnSetView.distribution = .gravityAreas
         } else if numberOfStretchItems == 0 && numberOfWeightedItems == 0 {
             columnSetView.distribution = .gravityAreas
         } else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -9,6 +9,7 @@ import AdaptiveCards_bridge
 import AppKit
 
 class ACRColumnSetView: ACRContentStackView {
+    var numberOfColumns: Int?
     // AccessibleFocusView property
     override var validKeyView: NSView? {
         get {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -66,6 +66,8 @@ class ACRColumnView: ACRContentStackView {
         return view
     }()
     
+    private var numberOfColumns: Int?
+    
     // AccessibleFocusView property
     override var validKeyView: NSView? {
         get {
@@ -132,8 +134,11 @@ class ACRColumnView: ACRContentStackView {
     }
     
     func configureColumnProperties(for view: NSView) {
-        if view is ACRDateField || view is ACRSingleLineInputTextView || view is ACRMultilineInputTextView {
+        if view is ACRDateField || view is ACRSingleLineInputTextView || view is ACRMultilineInputTextView || view is ACRNumericTextField {
             minWidthConstraint.constant = 100
+            if let numberOfColumns = numberOfColumns, numberOfColumns > 3 {
+                minWidthConstraint.constant = 60
+            }
         }
         manageWidth(of: view)
     }
@@ -142,6 +147,10 @@ class ACRColumnView: ACRContentStackView {
         columnWidth = width
         manageWidth(of: self)
         manageWidth(of: stackView)
+    }
+    
+    func setNumberOfColumns(_ value: Int?) {
+        self.numberOfColumns = value
     }
     
     private func manageWidth(of view: NSView) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -17,6 +17,7 @@ class ACRView: ACRColumnView {
     private var firstFieldWithError: InputHandlingViewProtocol?
     private (set) var visibilityContext: ACOVisibilityContext?
     private (set) var accessibilityContext: ACSAccessibilityFocusManager?
+    private (set) var cardWidth: CGFloat?
     
     // AccessibleFocusView property
     override var validKeyView: NSView? {
@@ -87,6 +88,10 @@ class ACRView: ACRColumnView {
     
     func getImageDimensions(for url: String) -> NSSize? {
         return resolverDelegate?.adaptiveCard(self, dimensionsForImageWith: url)
+    }
+    
+    func setCardWidth(_ value: CGFloat?) {
+        self.cardWidth = value
     }
     
     func resetKeyboardFocus() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.swift
@@ -91,7 +91,7 @@ class AdaptiveCardsTests: XCTestCase {
         let cardView = AdaptiveCard.render(card: card, with: hostConfig, width: 432, actionDelegate: delegate, resourceResolver: resourceResolver)
         
         // get the show card button to show child card view
-        guard let showCardButton = cardView.buttonInHierachy(withTitle: "Showcard1") else {
+        guard let showCardButton = cardView.buttonInHierachy(withTitle: "ShowCard1") else {
             XCTFail()
             return
         }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -130,21 +130,17 @@ class ColumnSetRendererTests: XCTestCase {
     func testColumnSetWithMultipleColumns() {
         let columns: [FakeColumn] = [.make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto")]
         columnSet = .make(columns: columns)
-        let parentView = NSView()
-        parentView.widthAnchor.constraint(equalToConstant: 540).isActive = true
-        let columnSetView = renderColumnSetView(parentView: parentView)
+        let columnSetView = renderColumnSetView()
         
         // Since more than 5 columns width gets divided equally
-        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 90)
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 72)
         XCTAssertEqual(columnSetView.arrangedSubviews[0].bounds.width, columnSetView.arrangedSubviews[1].bounds.width)
     }
     
     func testColumnSetWithMultipleInputElementInColumns() {
         let columns: [FakeColumn] = [.make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()])]
         columnSet = .make(columns: columns)
-        let parentView = NSView()
-        parentView.widthAnchor.constraint(equalToConstant: 500).isActive = true
-        let columnSetView = renderColumnSetView(parentView: parentView)
+        let columnSetView = renderColumnSetView()
         // Since 3 or less column, width is min 100
         XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 100)
         // Since there is padding between the columns are present in position 0, 2, 4
@@ -154,9 +150,7 @@ class ColumnSetRendererTests: XCTestCase {
     func testColumnSetWithFourInputElementInColumns() {
         let columns: [FakeColumn] = [.make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()])]
         columnSet = .make(columns: columns)
-        let parentView = NSView()
-        parentView.widthAnchor.constraint(equalToConstant: 500).isActive = true
-        let columnSetView = renderColumnSetView(parentView: parentView)
+        let columnSetView = renderColumnSetView()
         // Since more than 3 column, width is min 100
         
         XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 60)
@@ -164,8 +158,8 @@ class ColumnSetRendererTests: XCTestCase {
         XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, columnSetView.arrangedSubviews[2].fittingSize.width)
     }
     
-    private func renderColumnSetView(parentView: NSView = NSView()) -> ACRContentStackView {
-        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: parentView, inputs: [], config: .default)
+    private func renderColumnSetView() -> ACRContentStackView {
+        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnSetView = view as? ACRContentStackView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -127,8 +127,45 @@ class ColumnSetRendererTests: XCTestCase {
         XCTAssertNoThrow(renderColumnSetView())
     }
     
-    private func renderColumnSetView() -> ACRContentStackView {
-        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
+    func testColumnSetWithMultipleColumns() {
+        let columns: [FakeColumn] = [.make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto"), .make(width: "auto")]
+        columnSet = .make(columns: columns)
+        let parentView = NSView()
+        parentView.widthAnchor.constraint(equalToConstant: 540).isActive = true
+        let columnSetView = renderColumnSetView(parentView: parentView)
+        
+        // Since more than 5 columns width gets divided equally
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 90)
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].bounds.width, columnSetView.arrangedSubviews[1].bounds.width)
+    }
+    
+    func testColumnSetWithMultipleInputElementInColumns() {
+        let columns: [FakeColumn] = [.make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()])]
+        columnSet = .make(columns: columns)
+        let parentView = NSView()
+        parentView.widthAnchor.constraint(equalToConstant: 500).isActive = true
+        let columnSetView = renderColumnSetView(parentView: parentView)
+        // Since 3 or less column, width is min 100
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 100)
+        // Since there is padding between the columns are present in position 0, 2, 4
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, columnSetView.arrangedSubviews[2].fittingSize.width)
+    }
+    
+    func testColumnSetWithFourInputElementInColumns() {
+        let columns: [FakeColumn] = [.make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()]), .make(width: "auto", items: [FakeInputText.make()])]
+        columnSet = .make(columns: columns)
+        let parentView = NSView()
+        parentView.widthAnchor.constraint(equalToConstant: 500).isActive = true
+        let columnSetView = renderColumnSetView(parentView: parentView)
+        // Since more than 3 column, width is min 100
+        
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, 60)
+        // Since there is padding between the columns are present in position 0, 2, 4, 6
+        XCTAssertEqual(columnSetView.arrangedSubviews[0].fittingSize.width, columnSetView.arrangedSubviews[2].fittingSize.width)
+    }
+    
+    private func renderColumnSetView(parentView: NSView = NSView()) -> ACRContentStackView {
+        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: parentView, inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnSetView = view as? ACRContentStackView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityChildToParent.json.dataset/Contents.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityChildToParent.json.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "ToggleVisibilityChildToParent.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityChildToParent.json.dataset/ToggleVisibilityChildToParent.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityChildToParent.json.dataset/ToggleVisibilityChildToParent.json
@@ -1,0 +1,172 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.2",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Column 1",
+              "wrap": true
+            }
+          ],
+          "style": "attention",
+          "id": "column1"
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Column 2",
+              "wrap": true
+            }
+          ],
+          "style": "attention",
+          "id": "column2"
+        }
+      ],
+      "style": "good",
+      "id": "columnSet"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.ToggleVisibility",
+      "title": "Column Set",
+      "targetElements": [
+        "columnSet"
+      ]
+    },
+    {
+      "type": "Action.ToggleVisibility",
+      "title": "Column Parent",
+      "targetElements": [
+        "column1"
+      ]
+    },
+    {
+      "type": "Action.ToggleVisibility",
+      "title": "Column 2",
+      "targetElements": [
+        "column2"
+      ]
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "ShowCard1",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "ActionSet",
+            "actions": [
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column Set",
+                "targetElements": [
+                  "columnSet"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column Child1",
+                "targetElements": [
+                  "column1"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column 2",
+                "targetElements": [
+                  "column2"
+                ]
+              },
+              {
+      "type": "Action.ShowCard",
+      "title": "ShowCard2",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "ActionSet",
+            "actions": [
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column Set",
+                "targetElements": [
+                  "columnSet"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column 1",
+                "targetElements": [
+                  "column1"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column 2",
+                "targetElements": [
+                  "column2"
+                ]
+              },
+              {
+      "type": "Action.ShowCard",
+      "title": "ShowCard3",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "ActionSet",
+            "actions": [
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column Set",
+                "targetElements": [
+                  "columnSet"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column 1",
+                "targetElements": [
+                  "column1"
+                ]
+              },
+              {
+                "type": "Action.ToggleVisibility",
+                "title": "Column 2",
+                "targetElements": [
+                  "column2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "id": "showCard3"
+    }
+            ]
+          }
+        ]
+      },
+      "id": "showCard2"
+    }
+            ]
+          }
+        ]
+      },
+      "id": "showCard"
+    }
+  ]
+}
+

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithMinHeight.json.dataset/Contents.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithMinHeight.json.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "ToggleVisibilityWithMinHeight.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithMinHeight.json.dataset/ToggleVisibilityWithMinHeight.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithMinHeight.json.dataset/ToggleVisibilityWithMinHeight.json
@@ -1,0 +1,175 @@
+{
+   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+   "actions": [
+      {
+         "card": {
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "body": [
+               {
+                  "errorMessage": "error message error message error message error message ",
+                  "height": "stretch",
+                  "id": "11",
+                  "isRequired": true,
+                  "isVisible": true,
+                  "label": "Hello this is label",
+                  "type": "Input.Date"
+               },
+               {
+                  "errorMessage": "error message error message error message error message ",
+                  "height": "stretch",
+                  "id": "33",
+                  "isRequired": true,
+                  "isVisible": true,
+                  "label": "This is label",
+                  "type": "Input.Time"
+               },
+               {
+                  "type": "Container",
+                  "items": [
+                     {
+                        "type": "Input.Text",
+                        "height": "stretch",
+                        "placeholder": "Placeholder text",
+                        "id": "test2",
+                        "label": "Input Text"
+                     }
+                  ],
+                  "height": "stretch",
+                  "minHeight": "200px"
+               },
+               {
+                  "actions": [
+                     {
+                        "targetElements": [
+                           "11",
+                           "33"
+                        ],
+                        "title": "Action.ToggleVisibility",
+                        "type": "Action.ToggleVisibility"
+                     }
+                  ],
+                  "id": "22",
+                  "type": "ActionSet"
+               }
+            ],
+            "minHeight": "450px",
+            "type": "AdaptiveCard",
+            "version": "1.3"
+         },
+         "title": "Action.ShowCard",
+         "type": "Action.ShowCard"
+      }
+   ],
+   "body": [
+      {
+         "height": "stretch",
+         "items": [
+            {
+               "errorMessage": "error message error message error message error message ",
+               "height": "stretch",
+               "id": "1",
+               "isRequired": true,
+               "isVisible": true,
+               "label": "Hello this is label",
+               "type": "Input.Date"
+            },
+            {
+               "errorMessage": "error message error message error message error message ",
+               "height": "stretch",
+               "id": "3",
+               "isRequired": true,
+               "isVisible": true,
+               "label": "This is label",
+               "type": "Input.Time"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "1",
+                        "3"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "2",
+               "type": "ActionSet"
+            }
+         ],
+         "minHeight": "400px",
+         "type": "Container"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test1",
+               "label": "Input Text"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test3",
+               "label": "Input Text"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "test3"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "ac2",
+               "type": "ActionSet"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      },
+      {
+         "type": "Container",
+         "items": [
+            {
+               "type": "Input.Text",
+               "height": "stretch",
+               "placeholder": "Placeholder text",
+               "id": "test4",
+               "label": "Input Text"
+            },
+            {
+               "actions": [
+                  {
+                     "targetElements": [
+                        "test4"
+                     ],
+                     "title": "Action.ToggleVisibility",
+                     "type": "Action.ToggleVisibility"
+                  }
+               ],
+               "id": "ac3",
+               "type": "ActionSet"
+            }
+         ],
+         "height": "stretch",
+         "minHeight": "200px"
+      }
+   ],
+   "type": "AdaptiveCard",
+   "version": "1.3"
+}
+

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithoutMinHeight.json.dataset/Contents.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithoutMinHeight.json.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "ToggleVisibilityWithoutMinHeight.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithoutMinHeight.json.dataset/ToggleVisibilityWithoutMinHeight.json
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/TestResources.xcassets/ToggleVisibilityWithoutMinHeight.json.dataset/ToggleVisibilityWithoutMinHeight.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "actions": [
+        {
+            "card": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "body": [
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "11",
+                        "isRequired": true,
+                        "isVisible": true,
+                        "label": "Hello this is label",
+                        "type": "Input.Date"
+                    },
+                    {
+                        "errorMessage": "error message error message error message error message ",
+                        "height": "stretch",
+                        "id": "33",
+                        "isRequired": true,
+                        "isVisible": true,
+                        "label": "This is label",
+                        "type": "Input.Time"
+                    },
+                    {
+                        "type": "Container",
+                        "items": [
+                            {
+                                "type": "Input.Text",
+                                "height": "stretch",
+                                "placeholder": "Placeholder text",
+                                "id": "test2",
+                                "label": "Input Text"
+                            }
+                        ],
+                        "height": "stretch"
+                    },
+                    {
+                        "actions": [
+                            {
+                                "targetElements": [
+                                    "11",
+                                    "33"
+                                ],
+                                "title": "Action.ToggleVisibility",
+                                "type": "Action.ToggleVisibility"
+                            }
+                        ],
+                        "id": "22",
+                        "type": "ActionSet"
+                    }
+                ],
+                "type": "AdaptiveCard",
+                "version": "1.3"
+            },
+            "title": "Action.ShowCard",
+            "type": "Action.ShowCard"
+        }
+    ],
+    "body": [
+        {
+            "height": "stretch",
+            "items": [
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "1",
+                    "isRequired": true,
+                    "isVisible": true,
+                    "label": "Hello this is label",
+                    "type": "Input.Date"
+                },
+                {
+                    "errorMessage": "error message error message error message error message ",
+                    "height": "stretch",
+                    "id": "3",
+                    "isRequired": true,
+                    "isVisible": true,
+                    "label": "This is label",
+                    "type": "Input.Time"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "1",
+                                "3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "2",
+                    "type": "ActionSet"
+                }
+            ],
+            "type": "Container"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test1",
+                    "label": "Input Text"
+                }
+            ],
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test3",
+                    "label": "Input Text"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "test3"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "ac2",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "height": "stretch",
+                    "placeholder": "Placeholder text",
+                    "id": "test4",
+                    "label": "Input Text"
+                },
+                {
+                    "actions": [
+                        {
+                            "targetElements": [
+                                "test4"
+                            ],
+                            "title": "Action.ToggleVisibility",
+                            "type": "Action.ToggleVisibility"
+                        }
+                    ],
+                    "id": "ac3",
+                    "type": "ActionSet"
+                }
+            ],
+            "height": "stretch"
+        }
+    ],
+    "type": "AdaptiveCard",
+    "version": "1.3"
+}
+


### PR DESCRIPTION


# Description

Columnset with all colums having auto width wasn't respecting the auto width property, instead it was forcing each column to have equal width. This has been fixed in the current PR. 
There is an edge case where if there are a large number of columns we still set all columns to have equal width to make sure all elements have some screen real estate at least

# Sample Card

Before:
<img width="500" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/ef6c73a7-6021-4dc2-b468-870914dafc0a">
<img width="453" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/debafc28-e438-4915-bace-ad8555d51c10">


After:
<img width="494" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/ec097baf-cf91-4663-95ec-cf88a1220ba7">
<img width="493" alt="image" src="https://github.com/webex/AdaptiveCards/assets/78855675/b0c7cba1-aee0-4837-a0bb-d0124f67a229">


# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
