### PR TITLE
[macOS] Fix: Focus goes inside the hidden ShowCard

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -23,7 +23,7 @@ class ACRDateField: NSView {
         let view = ACRTextField(textFieldWith: config, mode: .dateTime, inputElement: inputElement)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isEditable = true
-        view.isSelectable = true
+        view.isSelectable = false
         view.cell?.lineBreakMode = .byTruncatingTail
         view.stringValue = ""
         view.textFieldDelegate = self
@@ -119,11 +119,11 @@ class ACRDateField: NSView {
     }
     
     override var canBecomeKeyView: Bool {
-        return textField.canBecomeKeyView
+        return !textField.visibleRect.isEmpty
     }
     
     override var acceptsFirstResponder: Bool {
-        return textField.acceptsFirstResponder
+        return !textField.visibleRect.isEmpty
     }
     
     override public var focusRingMaskBounds: NSRect {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -23,7 +23,7 @@ class ACRDateField: NSView {
         let view = ACRTextField(textFieldWith: config, mode: .dateTime, inputElement: inputElement)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isEditable = true
-        view.isSelectable = false
+        view.isSelectable = true
         view.cell?.lineBreakMode = .byTruncatingTail
         view.stringValue = ""
         view.textFieldDelegate = self
@@ -119,11 +119,11 @@ class ACRDateField: NSView {
     }
     
     override var canBecomeKeyView: Bool {
-        return true
+        return textField.canBecomeKeyView
     }
     
     override var acceptsFirstResponder: Bool {
-        return true
+        return textField.acceptsFirstResponder
     }
     
     override public var focusRingMaskBounds: NSRect {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
@@ -230,6 +230,13 @@ class ACRTextField: NSTextField {
         return accessibilityTitle
     }
     
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if textFieldMode == .dateTime {
+            return nil
+        }
+        return self
+    }
+    
     private var lastCursorPosition: Int?
     private func updateLastKnownCursorPosition() {
         guard let selectedRange = currentEditor()?.selectedRange else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
@@ -230,13 +230,6 @@ class ACRTextField: NSTextField {
         return accessibilityTitle
     }
     
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        if textFieldMode == .dateTime {
-            return nil
-        }
-        return self
-    }
-    
     private var lastCursorPosition: Int?
     private func updateLastKnownCursorPosition() {
         guard let selectedRange = currentEditor()?.selectedRange else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextView.swift
@@ -43,7 +43,7 @@ class ACRTextView: NSTextView, SelectActionHandlingProtocol {
     weak var exitView: AccessibleFocusView?
     
     override public var canBecomeKeyView: Bool {
-        return isEditable ? true : hasLinks
+        return isEditable ? super.canBecomeKeyView : hasLinks
     }
     
     override public var focusRingMaskBounds: NSRect {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
@@ -12,6 +12,7 @@ class FakeInputDate: ACSDateInput {
     public var label: String?
     public var separator: Bool = false
     public var height: ACSHeightType = .auto
+    public var spacing: ACSSpacing = .default
 
     open override func getValue() -> String? {
         return value
@@ -100,10 +101,18 @@ class FakeInputDate: ACSDateInput {
     open override func getType() -> ACSCardElementType {
         return .dateInput
     }
+    
+    override func getSpacing() -> ACSSpacing {
+        return spacing
+    }
+    
+    override func setSpacing(_ value: ACSSpacing) {
+        spacing = value
+    }
 }
 
 extension FakeInputDate {
-    static func make(id: String? = "", value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "", isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false, heightType: ACSHeightType = .auto) -> FakeInputDate {
+    static func make(id: String? = "", value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "", isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false, spacing: ACSSpacing = .default, heightType: ACSHeightType = .auto) -> FakeInputDate {
         let fakeInputDate = FakeInputDate()
         fakeInputDate.id = id
         fakeInputDate.value = value
@@ -114,6 +123,7 @@ extension FakeInputDate {
         fakeInputDate.errorMessage = errorMessage
         fakeInputDate.label = label
         fakeInputDate.separator = separator
+        fakeInputDate.spacing = spacing
         fakeInputDate.height = heightType
         return fakeInputDate
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -597,7 +597,8 @@ class ACRViewTests: XCTestCase {
         let actionSet = FakeActionSet.make(actions:
                                             [
                                                 FakeSubmitAction.make(),
-                                                FakeShowCardAction.make(card: FakeAdaptiveCard.make(actions: [FakeToggleVisibilityAction.make(targetElements: [FakeToggleVisibilityTarget.make(elementId: "input_text")])]))
+                                                FakeShowCardAction.make(card: FakeAdaptiveCard.make(body: [inputMultiText, inputDate],
+                                                                                                    actions: [FakeToggleVisibilityAction.make(targetElements: [FakeToggleVisibilityTarget.make(elementId: "input_text")])]))
                                             ])
         
         let actionSetView = try XCTUnwrap(ActionSetRenderer().render(element: actionSet, with: hostConfig, style: .default, rootView: view, parentView: view, inputs: [], config: config) as? ACRActionSetView)
@@ -631,11 +632,15 @@ class ACRViewTests: XCTestCase {
         actionButtons[1].performClick()
         
         let subCardView = try XCTUnwrap(actionSetView.currentShowCardItems?.showCard as? ACRView)
-        let subActionSetView = try XCTUnwrap(subCardView.arrangedSubviews.first as? ACRActionSetView)
+        let multilineTextView = try XCTUnwrap(subCardView.arrangedSubviews.first as? ACRMultilineInputTextView)
+        let dateInputView = try XCTUnwrap(subCardView.arrangedSubviews[2] as? ACRDateField)
+        let subActionSetView = try XCTUnwrap(subCardView.arrangedSubviews[3] as? ACRActionSetView)
         let subActionButtons = try XCTUnwrap(subActionSetView.actions as? [ACRButton])
         
         XCTAssertEqual(actionButtons[1].exitView?.validKeyView, subCardView)
-        XCTAssertEqual(subCardView.exitView?.validKeyView, subActionButtons[0])
+        XCTAssertEqual(subCardView.exitView?.validKeyView, multilineTextView.validKeyView)
+        XCTAssertEqual(multilineTextView.exitView?.validKeyView, dateInputView.validKeyView)
+        XCTAssertEqual(dateInputView.exitView?.validKeyView, subActionButtons[0].validKeyView)
         XCTAssertEqual(subActionButtons[0].exitView?.validKeyView, textView.validKeyView)
         
         /// Action Toggle


### PR DESCRIPTION
# Related Issue

- update MultilineText input
- update Date-Time Input
- update test

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

Original             	   |  Updated
:-------------------------:|:-------------------------:
![Jun-27-2023 12-22-09](https://github.com/webex/AdaptiveCards/assets/105660080/c00ce52a-8675-4429-a5d5-f0aaa24ca1c3) | ![Jun-27-2023 12-21-48](https://github.com/webex/AdaptiveCards/assets/105660080/ebd23ed0-f57e-47d6-a8cc-7d87a5860407)



# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
