### PR TITLE
Fix: [macOS] collections element bleeds to bottom of card instead of just the edges

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ContainerBleedWithImage.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ContainerBleedWithImage.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "Container",
+            "style": "attention",
+            "items": [
+                {
+                    "type": "Container",
+                    "style": "good",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "This Container bleeds into its parent padding for a nice visual appearance!",
+                            "wrap": true
+                        }
+                    ],
+                    "bleed": true
+                },
+                {
+                    "type": "Container",
+                    "style": "warning",
+                    "bleed": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "This Container is just a plain ol' container, it looks nice too though!",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ],
+            "bleed": true,
+            "backgroundImage": {
+                "url": "https://picsum.photos/200/200"
+            }
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.ShowCard",
+            "title": "Action.ShowCard",
+            "card": {
+                "type": "AdaptiveCard"
+            }
+        }
+    ]
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ContainerSelectAction.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ContainerSelectAction.json
@@ -185,7 +185,8 @@
                 "data": {
                     "info": "My submit action data"
                 }
-            }
+            },
+            "bleed": true
         },
         {
             "type": "TextBlock",
@@ -224,7 +225,8 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "bleed": true
                 },
                 {
                     "type": "Column",

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -62,7 +62,7 @@ class AdaptiveCardRenderer {
             let renderer = RendererManager.shared.renderer(for: element.getType())
             let view = renderer.render(element: element, with: hostConfig, style: style, rootView: rootView, parentView: rootView, inputs: [], config: config)
             BaseCardElementRenderer.shared.updateLayoutForSeparatorAndAlignment(view: view, element: element, parentView: rootView, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
-            BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: rootView, with: hostConfig, element: element, parentElement: nil)
+            BaseCardElementRenderer.shared.configBleed(for: view, with: hostConfig, element: element)
         }
         
         if !card.getActions().isEmpty {
@@ -84,6 +84,10 @@ class AdaptiveCardRenderer {
         
         if let backgroundImage = card.getBackgroundImage(), let url = backgroundImage.getUrl() {
             rootView.setupBackgroundImageProperties(backgroundImage)
+            let padding = CGFloat(truncating: hostConfig.getSpacing()?.paddingSpacing ?? 0)
+            // bleed view setup
+            rootView.setBleedViewConstraint(direction: (true, true, true, true), with: padding)
+            rootView.bleedBackgroundImage(direction: (true, true, true, true), with: padding)
             rootView.registerImageHandlingView(rootView.backgroundImageView, for: url)
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -86,8 +86,8 @@ class AdaptiveCardRenderer {
             rootView.setupBackgroundImageProperties(backgroundImage)
             let padding = CGFloat(truncating: hostConfig.getSpacing()?.paddingSpacing ?? 0)
             // bleed view setup
-            rootView.setBleedViewConstraint(direction: (true, true, true, true), with: padding)
-            rootView.bleedBackgroundImage(direction: (true, true, true, true), with: padding)
+            rootView.setBleedViewConstraint(direction: ACRBleedValue(top: true, bottom: true, leading: true, trailing: true), with: padding)
+            rootView.bleedBackgroundImage(direction: ACRBleedValue(top: true, bottom: true, leading: true, trailing: true), with: padding)
             rootView.registerImageHandlingView(rootView.backgroundImageView, for: url)
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -58,86 +58,30 @@ class BaseCardElementRenderer {
         view.setContentHuggingPriority(kFitViewHorizontalLayoutConstraintPriority, for: .horizontal)
     }
     
-    func configBleed(collectionView: NSView, parentView: ACRContentStackView, with hostConfig: ACSHostConfig, element: ACSBaseCardElement, parentElement: ACSBaseCardElement?) {
-        guard let collection = element as? ACSStyledCollectionElement, collection.getBleed() else {
-            return
-        }
-        guard let collectionView = collectionView as? ACRContentStackView else {
+    func configBleed(for view: NSView, with hostConfig: ACSHostConfig, element: ACSBaseCardElement) {
+        guard let collectionElem = element as? ACSStyledCollectionElement, collectionElem.getBleed() else { return }
+        guard let collectionView = view as? ACRContentStackView else {
             logError("Container is not type of ACRContentStackView")
             return
         }
-        // bleed specification requires the object that's asked to be bled to have padding
-        if collection.getPadding() {
-            let adaptiveBleedDirection = collection.getBleedDirection()
-            let direction = ACRBleedDirection(rawValue: adaptiveBleedDirection.rawValue)
-            
-            // 1. create a background view (bv).
-            // 2. Now, add bv to the parentView
-            // bv is then pinned to the parentView to the bleed direction
-            // bv gets current collection view's (cv) container style
-            // container view's stack view (csv) holds content views, and bv dislpays
-            // container style we transpose them, and get the final result
-            
-            if !collection.getCanBleed() {
-                return
+        guard collectionElem.getPadding(), collectionElem.getCanBleed() else { return }
+        
+        let padding = CGFloat(truncating: hostConfig.getSpacing()?.paddingSpacing ?? 0)
+        let bleedDirectionValues = ACRBleedDirection(rawValue: collectionElem.getBleedDirection().rawValue).getBleedValues()
+        
+        // stackview constraint setup for bleed
+        collectionView.setStackViewConstraint(direction: bleedDirectionValues)
+        
+        // bleed view setup
+        collectionView.setBleedViewConstraint(direction: bleedDirectionValues, with: padding)
+        
+        // background image setup
+        if collectionElem.getBackgroundImage() != nil {
+            if let columnView = collectionView as? ACRColumnView {
+                columnView.bleedBackgroundImage(direction: bleedDirectionValues, with: padding)
             }
-            
-            let top = ((direction.rawValue & ACRBleedDirection.ACRBleedToTopEdge.rawValue) != 0)
-            let leading = ((direction.rawValue & ACRBleedDirection.ACRBleedToLeadingEdge.rawValue) != 0)
-            let trailing = ((direction.rawValue & ACRBleedDirection.ACRBleedToTrailingEdge.rawValue) != 0)
-            let bottom = ((direction.rawValue & ACRBleedDirection.ACRBleedToBottomEdge.rawValue) != 0)
-            
-            var padding: CGFloat = 0
-            if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing {
-                padding = CGFloat(truncating: paddingSpace)
-            }
-            collectionView.setBleedProp(top: top, bottom: bottom, trailing: trailing, leading: leading)
-            var paddingBottom: CGFloat = 0
-            var bottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor> = collectionView.bottomAnchor
-            if bottom {
-                // case 1: when parent style == none,
-                // case 2: when parent is bleeding but, bottom bleed direction false
-                // case 3: when parent bleeds till end and has bottom bleed direction true
-                var parentBottomBleedDirection = false
-                if let parent = parentElement as? ACSStyledCollectionElement {
-                    let directionParent = parent.getBleedDirection()
-                    parentBottomBleedDirection = (directionParent.rawValue & ACRBleedDirection.ACRBleedToBottomEdge.rawValue) != 0
-                }
-                if let parentCollection = parentElement as? ACSStyledCollectionElement {
-                    paddingBottom = !parentCollection.getPadding() || (parentView.bleed && parentBottomBleedDirection
-                    ) ? padding : 0
-                }
-                bottomAnchor = parentView.bottomAnchor
-            }
-            
-            if collection.getBackgroundImage() != nil {
-                if let collectionView = collectionView as? ACRColumnView {
-                    collectionView.bleedBackgroundImage(padding: padding, top: top, bottom: bottom, leading: leading, trailing: trailing, paddingBottom: paddingBottom, with: bottomAnchor)
-                }
-                if let collectionView = collectionView as? ACRContainerView {
-                    collectionView.bleedBackgroundImage(padding: padding, top: top, bottom: bottom, leading: leading, trailing: trailing, paddingBottom: paddingBottom, with: bottomAnchor)
-                }
-                return
-            }
-            let backgroundView = NSView()
-            backgroundView.translatesAutoresizingMaskIntoConstraints = false
-            
-            // adding this above collectionView backgroundImage view
-            collectionView.addSubview(backgroundView, positioned: .below, relativeTo: collectionView.stackView)
-            backgroundView.wantsLayer = true
-            backgroundView.layer?.backgroundColor = collectionView.layer?.backgroundColor
-            
-            backgroundView.topAnchor.constraint(equalTo: collectionView.topAnchor, constant: top ? -padding : 0).isActive = true
-            backgroundView.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor, constant: leading ? -padding : 0).isActive = true
-            backgroundView.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor, constant: trailing ?  padding : 0).isActive = true
-            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: paddingBottom).isActive = true
-            
-            if let borderWidth = collectionView.layer?.borderWidth {
-                backgroundView.layer?.borderWidth = borderWidth
-            }
-            
-            if let borderColor = collectionView.layer?.borderColor {
-                backgroundView.layer?.borderColor = borderColor
+            if let containerView = collectionView as? ACRContainerView {
+                containerView.bleedBackgroundImage(direction: bleedDirectionValues, with: padding)
             }
         }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -29,7 +29,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             let view = renderer.render(element: element, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [], config: config)
             columnView.configureColumnProperties(for: view)
             BaseCardElementRenderer.shared.updateLayoutForSeparatorAndAlignment(view: view, element: element, parentView: columnView, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
-            BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: columnView, with: hostConfig, element: element, parentElement: column)
+            BaseCardElementRenderer.shared.configBleed(for: view, with: hostConfig, element: element)
         }
         
         columnView.configureLayoutAndVisibility(minHeight: column.getMinHeight())

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -16,6 +16,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         }
         let columnSetView = ACRColumnSetView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, renderConfig: config, superview: parentView, needsPadding: columnSet.getPadding())
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
+        columnSetView.bleed = columnSet.getBleed()
         if columnSet.getSelectAction() != nil {
             rootView.accessibilityContext?.registerView(columnSetView)
         }
@@ -45,7 +46,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             let columnView = ColumnRenderer.shared.render(element: column, with: hostConfig, style: columnSet.getStyle(), rootView: rootView, parentView: columnSetView, inputs: [], config: config)
             columnViews.append(columnView)
             updateColumnSetSeparatorAndAlignment(columnView: columnView, column: column, columnSetView: columnSetView, rootView: rootView, columnSet: columnSet, isfirstElement: isfirstElement, hostConfig: hostConfig)
-            BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column, parentElement: columnSet)
+            BaseCardElementRenderer.shared.configBleed(for: columnView, with: hostConfig, element: column)
         }
         
         // Add SelectAction

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -31,7 +31,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             let renderer = RendererManager.shared.renderer(for: element.getType())
             let view = renderer.render(element: element, with: hostConfig, style: container.getStyle(), rootView: rootView, parentView: containerView, inputs: [], config: config)
             BaseCardElementRenderer.shared.updateLayoutForSeparatorAndAlignment(view: view, element: element, parentView: containerView, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
-            BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: element, parentElement: container)
+            BaseCardElementRenderer.shared.configBleed(for: view, with: hostConfig, element: element)
         }
 
         containerView.configureLayoutAndVisibility(minHeight: container.getMinHeight())

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/BleedUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/BleedUtils.swift
@@ -1,6 +1,13 @@
 import AdaptiveCards_bridge
 import AppKit
 
+struct ACRBleedValue {
+    let top: Bool
+    let bottom: Bool
+    let leading: Bool
+    let trailing: Bool
+}
+
 struct ACRBleedDirection: OptionSet {
     let rawValue: UInt
     
@@ -11,11 +18,11 @@ struct ACRBleedDirection: OptionSet {
     static let ACRBleedToBottomEdge = ACRBleedDirection(rawValue: 1 << 3)
     static let ACRBleedToAll: ACRBleedDirection = [.ACRBleedToBottomEdge, .ACRBleedToLeadingEdge, .ACRBleedToTrailingEdge, .ACRBleedToTopEdge]
     
-    func getBleedValues() -> (top: Bool, bottom: Bool, leading: Bool, trailing: Bool) {
+    func getBleedValues() -> ACRBleedValue {
         let top = (self.rawValue & ACRBleedDirection.ACRBleedToTopEdge.rawValue) != 0
         let leading = (self.rawValue & ACRBleedDirection.ACRBleedToLeadingEdge.rawValue) != 0
         let trailing = (self.rawValue & ACRBleedDirection.ACRBleedToTrailingEdge.rawValue) != 0
         let bottom = (self.rawValue & ACRBleedDirection.ACRBleedToBottomEdge.rawValue) != 0
-        return (top, bottom, leading, trailing)
+        return ACRBleedValue(top: top, bottom: bottom, leading: leading, trailing: trailing)
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/BleedUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/BleedUtils.swift
@@ -10,4 +10,12 @@ struct ACRBleedDirection: OptionSet {
     static let ACRBleedToTopEdge = ACRBleedDirection(rawValue: 1 << 2)
     static let ACRBleedToBottomEdge = ACRBleedDirection(rawValue: 1 << 3)
     static let ACRBleedToAll: ACRBleedDirection = [.ACRBleedToBottomEdge, .ACRBleedToLeadingEdge, .ACRBleedToTrailingEdge, .ACRBleedToTopEdge]
+    
+    func getBleedValues() -> (top: Bool, bottom: Bool, leading: Bool, trailing: Bool) {
+        let top = (self.rawValue & ACRBleedDirection.ACRBleedToTopEdge.rawValue) != 0
+        let leading = (self.rawValue & ACRBleedDirection.ACRBleedToLeadingEdge.rawValue) != 0
+        let trailing = (self.rawValue & ACRBleedDirection.ACRBleedToTrailingEdge.rawValue) != 0
+        let bottom = (self.rawValue & ACRBleedDirection.ACRBleedToBottomEdge.rawValue) != 0
+        return (top, bottom, leading, trailing)
+    }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -85,7 +85,7 @@ class ACRColumnSetView: ACRContentStackView {
         self.setMinimumHeight(minHeight)
     }
     
-    override func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    override func setBleedViewConstraint(direction: ACRBleedValue, with padding: CGFloat) {
         // adding this below stackView
         addSubview(bleedView, positioned: .below, relativeTo: self.stackView)
         super.setBleedViewConstraint(direction: direction, with: padding)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -17,21 +17,6 @@ class ACRColumnSetView: ACRContentStackView {
         set { }
     }
     
-    override public func drawFocusRingMask() {
-        if self.target != nil {
-            if bleed {
-                if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-                    bleedView.bounds.offsetBy(dx: -padding, dy: -padding).fill()
-                } else {
-                    bleedView.bounds.fill()
-                }
-            } else {
-                self.bounds.fill()
-            }
-            self.needsDisplay = true
-        }
-    }
-    
     override func addArrangedSubview(_ view: NSView) {
         super.addArrangedSubview(view)
         self.increaseIntrinsicContentSize(view)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnSetView.swift
@@ -17,6 +17,21 @@ class ACRColumnSetView: ACRContentStackView {
         set { }
     }
     
+    override public func drawFocusRingMask() {
+        if self.target != nil {
+            if bleed {
+                if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
+                    bleedView.bounds.offsetBy(dx: -padding, dy: -padding).fill()
+                } else {
+                    bleedView.bounds.fill()
+                }
+            } else {
+                self.bounds.fill()
+            }
+            self.needsDisplay = true
+        }
+    }
+    
     override func addArrangedSubview(_ view: NSView) {
         super.addArrangedSubview(view)
         self.increaseIntrinsicContentSize(view)
@@ -83,5 +98,11 @@ class ACRColumnSetView: ACRContentStackView {
     override func configureLayoutAndVisibility(minHeight: NSNumber?) {
         self.applyVisibilityToSubviews()
         self.setMinimumHeight(minHeight)
+    }
+    
+    override func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+        // adding this below stackView
+        addSubview(bleedView, positioned: .below, relativeTo: self.stackView)
+        super.setBleedViewConstraint(direction: direction, with: padding)
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -167,14 +167,14 @@ class ACRColumnView: ACRContentStackView {
         }
     }
     
-    func bleedBackgroundImage(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    func bleedBackgroundImage(direction: ACRBleedValue, with padding: CGFloat) {
         backgroundImageViewTopConstraint.constant = direction.top ? -padding : 0
         backgroundImageViewTrailingConstraint.constant = direction.trailing ? padding : 0
         backgroundImageViewLeadingConstraint.constant = direction.leading ? -padding : 0
         backgroundImageViewBottomConstraint.constant = direction.bottom ?  padding : 0
     }
     
-    override func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    override func setBleedViewConstraint(direction: ACRBleedValue, with padding: CGFloat) {
         // adding this below collectionView backgroundImage view
         addSubview(bleedView, positioned: .below, relativeTo: self.backgroundImageView)
         super.setBleedViewConstraint(direction: direction, with: padding)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -75,21 +75,6 @@ class ACRColumnView: ACRContentStackView {
         set { }
     }
     
-    override public func drawFocusRingMask() {
-        if self.target != nil {
-            if bleed {
-                if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-                    bleedView.bounds.offsetBy(dx: -padding, dy: -padding).fill()
-                } else {
-                    bleedView.bounds.fill()
-                }
-            } else {
-                self.bounds.fill()
-            }
-            self.needsDisplay = true
-        }
-    }
-    
     override func addArrangedSubview(_ subview: NSView) {
         // Activate min Width constraint only if column has a non-image subview
         // Because - column can be empty                        -> should have zero content size

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContainerView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContainerView.swift
@@ -12,13 +12,14 @@ class ACRContainerView: ACRContentStackView {
     private (set) lazy var backgroundImageView: ACRBackgroundImageView = {
         let view = ACRBackgroundImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
         return view
     }()
     private lazy var widthConstraint = widthAnchor.constraint(equalToConstant: 30)
-    private lazy var backgroundImageViewBottomConstraint = backgroundImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
-    private lazy var backgroundImageViewTopConstraint = backgroundImageView.topAnchor.constraint(equalTo: topAnchor)
-    private lazy var backgroundImageViewLeadingConstraint = backgroundImageView.leadingAnchor.constraint(equalTo: leadingAnchor)
-    private lazy var backgroundImageViewTrailingConstraint = backgroundImageView.trailingAnchor.constraint(equalTo: trailingAnchor)
+    private (set) lazy var backgroundImageViewBottomConstraint = backgroundImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    private (set) lazy var backgroundImageViewTopConstraint = backgroundImageView.topAnchor.constraint(equalTo: topAnchor)
+    private (set) lazy var backgroundImageViewLeadingConstraint = backgroundImageView.leadingAnchor.constraint(equalTo: leadingAnchor)
+    private (set) lazy var backgroundImageViewTrailingConstraint = backgroundImageView.trailingAnchor.constraint(equalTo: trailingAnchor)
     
     // AccessibleFocusView property
     override var validKeyView: NSView? {
@@ -99,18 +100,23 @@ class ACRContainerView: ACRContentStackView {
     }
     
     func setupBackgroundImageProperties(_ properties: ACSBackgroundImage) {
+        backgroundImageView.isHidden = false
         backgroundImageView.fillMode = properties.getFillMode()
         backgroundImageView.horizontalAlignment = properties.getHorizontalAlignment()
         backgroundImageView.verticalAlignment = properties.getVerticalAlignment()
         heightAnchor.constraint(greaterThanOrEqualToConstant: 30).isActive = true
     }
     
-    func bleedBackgroundImage(padding: CGFloat, top: Bool, bottom: Bool, leading: Bool, trailing: Bool, paddingBottom: CGFloat, with anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>) {
-        backgroundImageViewTopConstraint.constant = top ? -padding : 0
-        backgroundImageViewTrailingConstraint.constant = trailing ? padding : 0
-        backgroundImageViewLeadingConstraint.constant = leading ? -padding : 0
-        backgroundImageViewBottomConstraint.isActive = false
-        backgroundImageViewBottomConstraint = backgroundImageView.bottomAnchor.constraint(equalTo: anchor, constant: bottom ?  padding : 0)
-        backgroundImageViewBottomConstraint.isActive = true
+    func bleedBackgroundImage(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+        backgroundImageViewTopConstraint.constant = direction.top ? -padding : 0
+        backgroundImageViewTrailingConstraint.constant = direction.trailing ? padding : 0
+        backgroundImageViewLeadingConstraint.constant = direction.leading ? -padding : 0
+        backgroundImageViewBottomConstraint.constant = direction.bottom ?  padding : 0
+    }
+    
+    override func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+        // adding this below collectionView backgroundImage view
+        addSubview(bleedView, positioned: .below, relativeTo: self.backgroundImageView)
+        super.setBleedViewConstraint(direction: direction, with: padding)
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContainerView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContainerView.swift
@@ -107,14 +107,14 @@ class ACRContainerView: ACRContentStackView {
         heightAnchor.constraint(greaterThanOrEqualToConstant: 30).isActive = true
     }
     
-    func bleedBackgroundImage(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    func bleedBackgroundImage(direction: ACRBleedValue, with padding: CGFloat) {
         backgroundImageViewTopConstraint.constant = direction.top ? -padding : 0
         backgroundImageViewTrailingConstraint.constant = direction.trailing ? padding : 0
         backgroundImageViewLeadingConstraint.constant = direction.leading ? -padding : 0
         backgroundImageViewBottomConstraint.constant = direction.bottom ?  padding : 0
     }
     
-    override func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    override func setBleedViewConstraint(direction: ACRBleedValue, with padding: CGFloat) {
         // adding this below collectionView backgroundImage view
         addSubview(bleedView, positioned: .below, relativeTo: self.backgroundImageView)
         super.setBleedViewConstraint(direction: direction, with: padding)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -208,7 +208,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         stackViewBottomLayoutConstraint?.constant = -padding
     }
     
-    func setStackViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool)) {
+    func setStackViewConstraint(direction: ACRBleedValue) {
         if direction.top {
             stackViewTopLayoutConstraint?.constant = 0
         }
@@ -223,7 +223,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         }
     }
     
-    func setBleedViewConstraint(direction: (top: Bool, bottom: Bool, leading: Bool, trailing: Bool), with padding: CGFloat) {
+    func setBleedViewConstraint(direction: ACRBleedValue, with padding: CGFloat) {
         bleedViewLeadingLayoutConstraint?.constant = direction.leading ? -padding : 0
         bleedViewTopLayoutConstraint?.constant = direction.top ? -padding : 0
         bleedViewTrailingLayoutConstraint?.constant = direction.trailing ? padding : 0

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -111,20 +111,12 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     }
     
     override public var focusRingMaskBounds: NSRect {
-        return bleed ? self.bleedView.bounds : self.bounds
+        return self.bounds
     }
     
     override public func drawFocusRingMask() {
         if self.target != nil {
-            if bleed {
-                if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-                    bleedView.bounds.offsetBy(dx: -padding, dy: 0).fill()
-                } else {
-                    bleedView.bounds.fill()
-                }
-            } else {
-                self.bounds.fill()
-            }
+            self.bounds.fill()
             self.needsDisplay = true
         }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
@@ -82,6 +82,14 @@ class FakeColumn: ACSColumn {
         bleed = value
     }
     
+    override func getCanBleed() -> Bool {
+        return true
+    }
+    
+    override func getBleedDirection() -> ACSContainerBleedDirection {
+        return .bleedAll
+    }
+    
     override func getSpacing() -> ACSSpacing {
         return spacing
     }
@@ -131,6 +139,7 @@ extension FakeColumn {
         fakeColumn.verticalContentAlignment = verticalContentAlignment
         fakeColumn.minHeight = minHeight
         fakeColumn.bleed = bleed
+        fakeColumn.padding = padding
         fakeColumn.spacing = spacing
         fakeColumn.height = height
         fakeColumn.separator = separator

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
@@ -12,7 +12,6 @@ class FakeColumnSet: ACSColumnSet {
     var height: ACSHeightType = .auto
     var type: ACSCardElementType = .columnSet
     var bleed: Bool = false
-    var backgroundImage: ACSBackgroundImage?
     var separator: Bool = false
     var visible: Bool = true
     
@@ -60,6 +59,10 @@ class FakeColumnSet: ACSColumnSet {
         return padding
     }
     
+    override func setPadding(_ value: Bool) {
+        padding = value
+    }
+    
     override func getMinHeight() -> NSNumber? {
         return minHeight
     }
@@ -84,12 +87,12 @@ class FakeColumnSet: ACSColumnSet {
         bleed = value
     }
     
-    open override func getBackgroundImage() -> ACSBackgroundImage? {
-        return backgroundImage
+    override func getCanBleed() -> Bool {
+        return true
     }
     
-    open override func setBackgroundImage(_ value: ACSBackgroundImage?) {
-        backgroundImage = value
+    override func getBleedDirection() -> ACSContainerBleedDirection {
+        return .bleedAll
     }
     
     override func getSeparator() -> Bool {
@@ -99,10 +102,14 @@ class FakeColumnSet: ACSColumnSet {
     override func getIsVisible() -> Bool {
         return visible
     }
+    
+    override func getBackgroundImage() -> ACSBackgroundImage? {
+        return nil
+    }
 }
 
 extension FakeColumnSet {
-    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default, selectAction: ACSBaseActionElement? = nil, horizontalAlignment: ACSHorizontalAlignment = .left, padding: Bool = false, heightType: ACSHeightType = .auto) -> FakeColumnSet {
+    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default, selectAction: ACSBaseActionElement? = nil, horizontalAlignment: ACSHorizontalAlignment = .left, bleed: Bool = false, padding: Bool = false, heightType: ACSHeightType = .auto) -> FakeColumnSet {
        let fakeColumnSet = FakeColumnSet()
         fakeColumnSet.columns = columns
         fakeColumnSet.style = style
@@ -110,6 +117,7 @@ extension FakeColumnSet {
         fakeColumnSet.horizontalAlignment = horizontalAlignment
         fakeColumnSet.padding = padding
         fakeColumnSet.height = heightType
+        fakeColumnSet.bleed = bleed
         return fakeColumnSet
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
@@ -43,6 +43,14 @@ class FakeContainer: ACSContainer {
         bleed = value
     }
     
+    override func getCanBleed() -> Bool {
+        return true
+    }
+    
+    override func getBleedDirection() -> ACSContainerBleedDirection {
+        return .bleedAll
+    }
+    
     open override func getBackgroundImage() -> ACSBackgroundImage? {
         return backgroundImage
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -63,6 +63,36 @@ class ColumnRendererTests: XCTestCase {
         XCTAssertEqual(columnView.arrangedSubviews.count, 2)
     }
     
+    func testBleedView() {
+        let backgroundImage = FakeBackgroundImage.make(url: "https://picsum.photos/200", fillMode: .cover)
+        hostConfig = .make(spacing: ACSSpacingConfig.init(smallSpacing: 4, defaultSpacing: 6, mediumSpacing: 8, largeSpacing: 10, extraLargeSpacing: 14, paddingSpacing: 12))
+        
+        let column = FakeColumn.make(bleed: true, backgroundImage: backgroundImage, padding: true)
+        let columnView = renderColumnView(column)
+        
+        XCTAssertFalse(columnView.bleedViewTopLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnView.bleedViewBottomLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnView.bleedViewLeadingLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnView.bleedViewTrailingLayoutConstraint?.isActive ?? true)
+        
+        BaseCardElementRenderer.shared.configBleed(for: columnView, with: hostConfig, element: column)
+        
+        XCTAssertEqual(columnView.bleedViewTopLayoutConstraint?.constant, -12)
+        XCTAssertEqual(columnView.bleedViewBottomLayoutConstraint?.constant, 12)
+        XCTAssertEqual(columnView.bleedViewLeadingLayoutConstraint?.constant, -12)
+        XCTAssertEqual(columnView.bleedViewTrailingLayoutConstraint?.constant, 12)
+        
+        XCTAssertEqual(columnView.backgroundImageViewTopConstraint.constant, -12)
+        XCTAssertEqual(columnView.backgroundImageViewBottomConstraint.constant, 12)
+        XCTAssertEqual(columnView.backgroundImageViewLeadingConstraint.constant, -12)
+        XCTAssertEqual(columnView.backgroundImageViewTrailingConstraint.constant, 12)
+        
+        XCTAssertEqual(columnView.stackViewTopLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnView.stackViewBottomLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnView.stackViewLeadingLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnView.stackViewTrailingLayoutConstraint?.constant, 0)
+    }
+    
     func testSelectActionTargetIsSet() {
         var columnView: ACRColumnView!
         

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -63,6 +63,30 @@ class ColumnSetRendererTests: XCTestCase {
         XCTAssertEqual(columnSetView.distribution, .fill)
     }
     
+    func testBleedView() {
+        hostConfig = .make(spacing: ACSSpacingConfig.init(smallSpacing: 4, defaultSpacing: 6, mediumSpacing: 8, largeSpacing: 10, extraLargeSpacing: 14, paddingSpacing: 12))
+        columnSet = .make(columns: [FakeColumn.make(), FakeColumn.make()], bleed: true, padding: true)
+        
+        let columnSetView = renderColumnSetView()
+        
+        XCTAssertFalse(columnSetView.bleedViewTopLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnSetView.bleedViewBottomLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnSetView.bleedViewLeadingLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(columnSetView.bleedViewTrailingLayoutConstraint?.isActive ?? true)
+        
+        BaseCardElementRenderer.shared.configBleed(for: columnSetView, with: hostConfig, element: columnSet)
+        
+        XCTAssertEqual(columnSetView.bleedViewTopLayoutConstraint?.constant, -12)
+        XCTAssertEqual(columnSetView.bleedViewBottomLayoutConstraint?.constant, 12)
+        XCTAssertEqual(columnSetView.bleedViewLeadingLayoutConstraint?.constant, -12)
+        XCTAssertEqual(columnSetView.bleedViewTrailingLayoutConstraint?.constant, 12)
+        
+        XCTAssertEqual(columnSetView.stackViewTopLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnSetView.stackViewBottomLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnSetView.stackViewLeadingLayoutConstraint?.constant, 0)
+        XCTAssertEqual(columnSetView.stackViewTrailingLayoutConstraint?.constant, 0)
+    }
+    
     func testDefaultOrientation() {
         let columnStackView = renderColumnSetView()
         XCTAssertEqual(columnStackView.orientation, .horizontal)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -37,6 +37,36 @@ class ContainerRendererTests: XCTestCase {
         XCTAssertEqual(rootStretchView.stackView.arrangedSubviews.first?.contentHuggingPriority(for: .vertical), kFillerViewLayoutConstraintPriority)
     }
     
+    func testBleedView() {
+        let backgroundImage = FakeBackgroundImage.make(url: "https://picsum.photos/200", fillMode: .cover)
+        hostConfig = .make(spacing: ACSSpacingConfig.init(smallSpacing: 4, defaultSpacing: 6, mediumSpacing: 8, largeSpacing: 10, extraLargeSpacing: 14, paddingSpacing: 12))
+        
+        let container = FakeContainer.make(bleed: true, backgroundImage: backgroundImage, padding: true)
+        let containerView = renderContainerView(container)
+        
+        XCTAssertFalse(containerView.bleedViewTopLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(containerView.bleedViewBottomLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(containerView.bleedViewLeadingLayoutConstraint?.isActive ?? true)
+        XCTAssertFalse(containerView.bleedViewTrailingLayoutConstraint?.isActive ?? true)
+        
+        BaseCardElementRenderer.shared.configBleed(for: containerView, with: hostConfig, element: container)
+        
+        XCTAssertEqual(containerView.bleedViewTopLayoutConstraint?.constant, -12)
+        XCTAssertEqual(containerView.bleedViewBottomLayoutConstraint?.constant, 12)
+        XCTAssertEqual(containerView.bleedViewLeadingLayoutConstraint?.constant, -12)
+        XCTAssertEqual(containerView.bleedViewTrailingLayoutConstraint?.constant, 12)
+        
+        XCTAssertEqual(containerView.backgroundImageViewTopConstraint.constant, -12)
+        XCTAssertEqual(containerView.backgroundImageViewBottomConstraint.constant, 12)
+        XCTAssertEqual(containerView.backgroundImageViewLeadingConstraint.constant, -12)
+        XCTAssertEqual(containerView.backgroundImageViewTrailingConstraint.constant, 12)
+        
+        XCTAssertEqual(containerView.stackViewTopLayoutConstraint?.constant, 0)
+        XCTAssertEqual(containerView.stackViewBottomLayoutConstraint?.constant, 0)
+        XCTAssertEqual(containerView.stackViewLeadingLayoutConstraint?.constant, 0)
+        XCTAssertEqual(containerView.stackViewTrailingLayoutConstraint?.constant, 0)
+    }
+    
     func testRendererSetsVerticalContentAlignment() {
         var container = FakeContainer.make(verticalContentAlignment: .top, items: [FakeTextBlock.make()])
         // Removing this since we don't need subviews to have padding to have explicit width


### PR DESCRIPTION
# Related Issue
- refactor bleed configuration at base render
- add new methods in collection element view
- bug fix
- add new unit test for bleed


**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

Before             	   |  Updated
:-------------------------:|:-------------------------:
<img width="446" alt="Screenshot 2023-06-28 at 3 41 03 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/93e7b9dd-ee6d-40b7-8b37-f91cf509b3fa"> | <img width="439" alt="Screenshot 2023-06-28 at 3 38 53 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/0eddb269-8307-4c28-a2db-be694b58277b">
<img width="445" alt="Screenshot 2023-06-28 at 3 40 04 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/a646768c-d0ef-403c-81f2-21271935151c"> | <img width="446" alt="Screenshot 2023-06-28 at 3 29 29 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/8627c8ea-76ea-4620-85c1-1cfa835399d4">
<img width="452" alt="Screenshot 2023-06-30 at 6 10 27 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/5592c6b4-fb6c-4256-ab85-6888a5497a40"> | <img width="443" alt="Screenshot 2023-06-30 at 6 09 03 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/2d542c79-adaf-414a-b00b-c20add90d5f9">
**Bleed Regressions Test** | **
<img width="441" alt="Screenshot 2023-06-28 at 3 41 54 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/58262532-930c-47db-9440-2d846b005ec3"> | <img width="441" alt="Screenshot 2023-06-28 at 3 41 54 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/5c0456f5-4c2f-46c5-9b39-57018687d135">
<img width="442" alt="Screenshot 2023-06-28 at 4 08 20 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/f91f314c-67d0-4c2e-8001-66256f3bcd47"> | <img width="441" alt="Screenshot 2023-06-28 at 4 13 33 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/54d90bd0-b04f-44a5-a121-70413066ef1b">
<img width="440" alt="Screenshot 2023-06-28 at 4 08 57 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/11791106-ac96-4efe-992f-ba638833926e"> | <img width="441" alt="Screenshot 2023-06-28 at 4 13 56 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/00aed505-dd8e-4398-8e7a-5316218be44d">
<img width="443" alt="Screenshot 2023-06-28 at 3 38 22 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/8a11ae45-456a-4ed2-882e-9eeb965f4852"> | <img width="443" alt="Screenshot 2023-06-28 at 3 38 22 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/2deb8354-7d1a-46f2-8d65-18f2e79c2831">
<img width="441" alt="Screenshot 2023-06-28 at 3 37 49 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/57c97ae7-5d78-4b20-a54c-a8c7e07faadf"> | <img width="441" alt="Screenshot 2023-06-28 at 3 37 49 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/7e48c0c4-99a0-46cf-8dfa-aa971522d333">
<img width="440" alt="Screenshot 2023-06-28 at 3 30 15 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/8d168d7f-e4c2-4c5a-816b-f56bf2c82f85"> | <img width="440" alt="Screenshot 2023-06-28 at 3 30 15 PM" src="https://github.com/webex/AdaptiveCards/assets/105660080/2bc0bb8b-6873-40e5-9541-658563d1a843">






# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
