### PR TITLE
SPARK-443311_Adaptive_Card_inputNumber_wrong_Fixed

### DIFF
--- a/source/qml/Library/RendererQml/NumberInputRender.cpp
+++ b/source/qml/Library/RendererQml/NumberInputRender.cpp
@@ -32,12 +32,12 @@ void NumberInputElement::initialize()
 
     if (mInput->GetValue().has_value())
     {
-        mNumberInputQmlElement->Property("_value", RendererQml::Formatter() << mInput->GetValue().value());
+        mNumberInputQmlElement->Property("_value", std::to_string(mInput->GetValue().value()));
         mNumberInputQmlElement->Property("_hasDefaultValue", "true");
     }
 
-    mNumberInputQmlElement->Property("_minValue", RendererQml::Formatter() << mInput->GetMin().value_or(-DBL_MAX));
-    mNumberInputQmlElement->Property("_maxValue", RendererQml::Formatter() << mInput->GetMax().value_or(DBL_MAX));
+    mNumberInputQmlElement->Property("_minValue", std::to_string(mInput->GetMin().value_or(-DBL_MAX)));
+    mNumberInputQmlElement->Property("_maxValue", std::to_string(mInput->GetMax().value_or(DBL_MAX)));
 
 
     if (mInput->GetIsRequired() || mInput->GetMin().has_value() || mInput->GetMax().has_value())


### PR DESCRIPTION
# Related Issue

A Pull Request should close a **single** issue; multiple issues can be closed when the issues are **small and related**, but that should be an exception not the rule. Please keep Pull Requests small and targeted; large 'code drops' with dozens of files will be closed and asked to split into reviewable pieces. Reviews that need to be large due to dependencies will be
reviewed on a case-by-case basis.

Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issue fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one to aid
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

-- Change related to conversion to string is done in NumberInputRender.cpp
The spinner press(up arrow), was exceeding the maxValue "max": 73999999 and reaching "max": 74000000, which is fixed. This was happening with numbers more than 6 digits.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
