### PR TITLE
SPARK-448250_Windows_Webex_app_43.7_crash

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveElementRenderers.h
+++ b/source/qml/Library/RendererQml/AdaptiveElementRenderers.h
@@ -53,7 +53,7 @@ namespace RendererQml
                 }
             }
 
-            throw std::invalid_argument(Formatter() << "Unable to locate renderer for " << type.name());
+            return nullptr;
         }
 
     private:


### PR DESCRIPTION
# Related Issue

A Pull Request should close a **single** issue; multiple issues can be closed when the issues are **small and related**, but that should be an exception not the rule. Please keep Pull Requests small and targeted; large 'code drops' with dozens of files will be closed and asked to split into reviewable pieces. Reviews that need to be large due to dependencies will be
reviewed on a case-by-case basis.

Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issue fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one to aid
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description
-- A single liner change in AdaptiveElementRenderers.h, instead of throwing an exception, we now returning a null ptr. That will silently ignore any unknown element in the card.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
