### PR TITLE
[mac]Fixed bug with associated inputs in show card

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/AssociatedInputNoneInShowCard.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/AssociatedInputNoneInShowCard.json
@@ -1,0 +1,42 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http:\/\/adaptivecards.io\/schemas\/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "ActionSet",
+            "actions": [
+                {
+                    "type": "Action.Submit",
+                    "title": "Submit",
+                    "data": {
+                        "wbm_command": "help"
+                    },
+                    "associatedInputs": "none"
+                },
+                {
+                    "type": "Action.ShowCard",
+                    "title": "Action.ShowCard",
+                    "card": {
+                        "type": "AdaptiveCard",
+                        "body": [
+                            {
+                                "type": "ActionSet",
+                                "actions": [
+                                    {
+                                        "type": "Action.Submit",
+                                        "title": "Submit",
+                                        "data": {
+                                            "wbm_command": "help"
+                                        },
+                                        "associatedInputs": "none"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+} 

--- a/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		281415F429EEF6200042F0FC /* ACSTableRow.h in Headers */ = {isa = PBXBuildFile; fileRef = 281415EC29EEF61F0042F0FC /* ACSTableRow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		281415F529EEF6200042F0FC /* ACSTableCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 281415ED29EEF6200042F0FC /* ACSTableCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		281950432703141500B0D790 /* HostConfigUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281950422703141500B0D790 /* HostConfigUtilsTests.swift */; };
+		283295702B299D3500979501 /* AdaptiveCardRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2832956F2B299D3500979501 /* AdaptiveCardRendererTests.swift */; };
 		2871B11825DD20A30040AB27 /* FakeTextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2871B11725DD20A30040AB27 /* FakeTextInput.swift */; };
 		2871B11D25DD225C0040AB27 /* ACRMultilineTextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2871B11C25DD225C0040AB27 /* ACRMultilineTextView.xib */; };
 		2871B12A25DD27F10040AB27 /* ACRMultilineInputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2871B12925DD27F10040AB27 /* ACRMultilineInputTextView.swift */; };
@@ -1043,6 +1044,7 @@
 		281415EC29EEF61F0042F0FC /* ACSTableRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACSTableRow.h; sourceTree = "<group>"; };
 		281415ED29EEF6200042F0FC /* ACSTableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACSTableCell.h; sourceTree = "<group>"; };
 		281950422703141500B0D790 /* HostConfigUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConfigUtilsTests.swift; sourceTree = "<group>"; };
+		2832956F2B299D3500979501 /* AdaptiveCardRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveCardRendererTests.swift; sourceTree = "<group>"; };
 		2871B11725DD20A30040AB27 /* FakeTextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTextInput.swift; sourceTree = "<group>"; };
 		2871B11C25DD225C0040AB27 /* ACRMultilineTextView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ACRMultilineTextView.xib; sourceTree = "<group>"; };
 		2871B12925DD27F10040AB27 /* ACRMultilineInputTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ACRMultilineInputTextView.swift; sourceTree = "<group>"; };
@@ -1494,6 +1496,7 @@
 				08FFAC2C2608DB6B00296D62 /* ActionOpenURLRendererTests.swift */,
 				2982B3F62628933C00E7561C /* BaseCardElementRendererTests.swift */,
 				086D82DA26AA9E0800CD2D0D /* ActionToggleVisibilityRendererTests.swift */,
+				2832956F2B299D3500979501 /* AdaptiveCardRendererTests.swift */,
 			);
 			path = Renderers;
 			sourceTree = "<group>";
@@ -2766,6 +2769,7 @@
 				08352EA52695CFB300B544C3 /* FakeInternalId.swift in Sources */,
 				082E59AE2604E96E00741958 /* FakeAdaptiveCard.swift in Sources */,
 				81AFEA7626281B9400DD47E0 /* ACRNumericTextFieldTests.swift in Sources */,
+				283295702B299D3500979501 /* AdaptiveCardRendererTests.swift in Sources */,
 				8107117C26E208E5001A7BC2 /* ACRMultilineTextViewTests.swift in Sources */,
 				0801EDB425F78EB800D64C86 /* FakeColumnSet.swift in Sources */,
 				2871B15025DD4C4D0040AB27 /* TextInputRedererTest.swift in Sources */,

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -24,6 +24,7 @@ class AdaptiveCardRenderer {
             logError("renderAdaptiveCard should return ACRView")
             return NSView()
         }
+        cardView.identifier = parent.identifier
         cardView.parent = parent
         return cardView
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/AdaptiveCardRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/AdaptiveCardRendererTests.swift
@@ -1,0 +1,34 @@
+//
+//  AdaptiveCardRendererTests.swift
+//  AdaptiveCardsTests
+//
+//  Created by mukuagar on 13/12/23.
+//
+
+@testable import AdaptiveCards
+import AdaptiveCards_bridge
+import XCTest
+
+class AdaptiveCardRendererTests: XCTestCase {
+    private var hostConfig: FakeHostConfig!
+    private var adaptiveCardRenderer: AdaptiveCardRenderer!
+    private var rootView: FakeRootView!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        hostConfig = .make()
+        adaptiveCardRenderer = AdaptiveCardRenderer()
+        rootView = FakeRootView()
+    }
+    
+    func testShowCardIdSameAsParent() {
+        let parentView = FakeRootView()
+        parentView.identifier = NSUserInterfaceItemIdentifier("test")
+        let fakeShowCard = FakeAdaptiveCard.make()
+        let showCardView = adaptiveCardRenderer.renderShowCard(fakeShowCard, with: hostConfig, parent: parentView, config: .default)
+        XCTAssertEqual(parentView.identifier, showCardView.identifier)
+        XCTAssertEqual(showCardView.identifier?.rawValue, "test")
+    }
+    
+}
+


### PR DESCRIPTION
# Description

When a card had a show card with a submit button and that submit button had associated input set as none, the submit button would not work. This has been fixed in this PR

RCA: We set the main card to have the messageID as the identifier, but do not set any for the child cards. This is usually not the problem for submitting since normally when we submit the child card passes it's data to main card and thus we use the identifier of main card to validate and send the message. But if the child card's submit has associatedInput set to none, we directly send the action to conversation bypassing the main card, so there is no messageID which fails our check and we do not submit.
To fix this, now all show cards have the same identifier(message ID) as the main card

# Sample Card

Added in json list

# How Verified

Added test
